### PR TITLE
Support io.buildpacks.stacks.bionic stack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "0.0.8"
+version = "0.0.9"
 
 [[stacks]]
 id = "heroku-18"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -7,3 +7,6 @@ version = "0.0.8"
 
 [[stacks]]
 id = "heroku-18"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
[This RFC](https://github.com/buildpacks/rfcs/pull/40) is working its way through and it seems useful to be able to use Heroku buildpacks on `cloudfoundry/cnb:bionic`. This also aligns with how riff is compatible with [multiple stacks](https://github.com/projectriff/node-function-buildpack/blob/master/buildpack.toml#L22).