### PR TITLE
[for DevPreview] Use SDK Context secrets API

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.0.1"
+version = "1.1.0"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -9,6 +9,7 @@ import {
     InvocationEvent,
     Logger,
     Org,
+    Secrets,
     SObject,
     SuccessResult,
     UnitOfWork,
@@ -129,7 +130,6 @@ function createOrg(logger: Logger, reqContext: any, accessToken?: string): Org {
 
     const apiVersion = reqContext.apiVersion || process.env.FX_API_VERSION || Constants.CURRENT_API_VERSION;
     const user = createUser(userContext);
-    const secrets = createSecrets(logger);
 
     // If accessToken was provided, setup APIs.
     let dataApi: DataApi | undefined;
@@ -151,8 +151,7 @@ function createOrg(logger: Logger, reqContext: any, accessToken?: string): Org {
         userContext.orgId,
         user,
         dataApi,
-        unitOfWork,
-        secrets
+        unitOfWork
     );
 }
 
@@ -170,7 +169,8 @@ function createContext(id: string, logger: Logger, reqContext?: any, accessToken
     }
 
     const org = reqContext ? createOrg(logger, reqContext!, accessToken) : undefined;
-    const context = new Context(id, logger, org);
+    const secrets = createSecrets(logger);
+    const context = new Context(id, logger, org, secrets);
 
     // If functionInvocationId is provided, create and set FunctionInvocationRequest object
     let fxInvocation: FunctionInvocationRequest;

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -148,25 +148,25 @@
       }
     },
     "@salesforce/kit": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-1.2.1.tgz",
-      "integrity": "sha512-ytpDL5TO4QAPcMl1flXXADMeBzARtoOZekWTMdL2O8PVdJo5Wbo9TNpJk0u6SN7qcxZvdbb6RAJpprp4qN2TZw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-1.2.2.tgz",
+      "integrity": "sha512-MQXUh8Ka8oB1SOPUF1kOynXQWcLeZ8YWOyqPtg6j8U9NxLlkTF2vfUfhZEm//jXjejDy7CEes5rEKRHm2df/OA==",
       "requires": {
-        "@salesforce/ts-types": "^1.2.1",
+        "@salesforce/ts-types": "^1.2.2",
         "tslib": "^1.10.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
-          "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
         }
       }
     },
     "@salesforce/salesforce-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/salesforce-sdk/-/salesforce-sdk-1.0.0.tgz",
-      "integrity": "sha512-8KhiSrCb7lORV7rOx7EcQG1TazTaNMKUiNAT859XHEa0+K43RYk9pZYXzYH9j2MIcr8pXEqpPafuLEq7YHKkfQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/salesforce-sdk/-/salesforce-sdk-1.1.0.tgz",
+      "integrity": "sha512-HSHIYZf3c/n8B8UIOsxfCOy/KEmmKTUZBCJGDgj+8FLlUM4x0qdTNfEeFDs+77hPwFSt3nLl78qEofVt/fuIcQ==",
       "requires": {
         "@salesforce/core": "2.1.6",
         "tslib": "1.10.0",
@@ -181,11 +181,11 @@
       }
     },
     "@salesforce/ts-sinon": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-sinon/-/ts-sinon-1.1.1.tgz",
-      "integrity": "sha512-veoaX1iaYmPbwnv28rds6BjmPJffTQ4NaXpgcEKcSVf18UsdhBxIF3NwMD2ZGws2HjVW5zBP3lbiYo+U4EsWNA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-sinon/-/ts-sinon-1.1.2.tgz",
+      "integrity": "sha512-DUzbsEGyYkfXAi4aoK/DWagld96xv6qUqhE8hwN+oakkzoCn5l75WSAXnbhsZicRgePqBUsudzCZv3yPrqtxnQ==",
       "requires": {
-        "@salesforce/ts-types": "^1.2.1",
+        "@salesforce/ts-types": "^1.2.2",
         "sinon": "5.1.1",
         "tslib": "^1.10.0"
       },
@@ -218,24 +218,24 @@
           }
         },
         "tslib": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
-          "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
         }
       }
     },
     "@salesforce/ts-types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.2.1.tgz",
-      "integrity": "sha512-kEpyfvTRfwQFpDc1rfb6aaQbl5SDIwCksgr8ftJaooGXDVWFK9llso9cwimee+KVqTeQ6Jf4tZclcPb8I6G6sg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.2.2.tgz",
+      "integrity": "sha512-inTkNP5jwJTbKqmBv6Cku/ezU6+ErYbUH4YorDfgZ/wDCsdLc9UyPGKGMO8aZ78vvyUTYWEiDxWlMqb1QXEfEw==",
       "requires": {
         "tslib": "^1.10.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
-          "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
         }
       }
     },
@@ -824,9 +824,9 @@
       }
     },
     "csv-parse": {
-      "version": "4.8.6",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.6.tgz",
-      "integrity": "sha512-rSJlpgAjrB6pmlPaqiBAp3qVtQHN07VxI+ozs+knMsNvgh4bDQgENKLFYLFMvT+jn/wr/zvqsd7IVZ7Txdkr7w=="
+      "version": "4.8.8",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.8.tgz",
+      "integrity": "sha512-Kv3Ilz2GV58dOoHBXRCTF8ijxlLjl80bG3d67XPI6DNqffb3AnbPbKr/WvCUMJq5V0AZYi6sukOaOQAVpfuVbg=="
     },
     "csv-stringify": {
       "version": "1.1.2",
@@ -2043,9 +2043,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -41,6 +41,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.9.0",
+    "minimist": ">=1.2.2",
     "mocha": "^5.2.0",
     "nyc": "^14.1.1",
     "pre-commit": "^1.2.2",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -26,7 +26,7 @@
   },
   "author": "TODO",
   "dependencies": {
-    "@salesforce/salesforce-sdk": "1.0.0",
+    "@salesforce/salesforce-sdk": "1.1.0",
     "tslib": "1.9.3"
   },
   "devDependencies": {

--- a/middleware/test/unit/ContextTests.ts
+++ b/middleware/test/unit/ContextTests.ts
@@ -30,6 +30,7 @@ describe('Context Tests', () => {
         expect(context.org.baseUrl).to.equal(data.context.userContext.salesforceBaseUrl);
         expect(context.org.user.username).to.equal(data.context.userContext.username);
         expect(context.org.user.id).to.equal(data.context.userContext.userId);
+        expect(context.secrets).to.exist;
 
         if (hasOnBehalfOfUserId) {
             expect(context.org.user.onBehalfOfUserId).to.equal(data.context.userContext.onBehalfOfUserId);
@@ -158,6 +159,20 @@ describe('Context Tests', () => {
     it('test logger DEBUG level when secret is set', () =>{
         const sname = 'sf-debug';
         const key = 'DEBUG';
+
+        // Stub out the fs calls made by Secrets
+        const fsStat = new fs.Stats();
+        sinon.stub(fsStat, 'isDirectory').returns(true);
+        sinon.stub(fsStat, 'isFile').returns(true);
+        sandbox.stub(fs, 'statSync')
+          .withArgs(`/platform/services/${sname}/secret`)
+          .returns(fsStat)
+          .withArgs(`/platform/services/${sname}/secret/${key}`)
+          .returns(fsStat);
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        sandbox.stub(fs, <any>'readdirSync')
+          .withArgs(`/platform/services/${sname}/secret`)
+          .returns([key]);
         sandbox.stub(fs, 'readFileSync')
           .withArgs(`/platform/services/${sname}/secret/${key}`)
           .returns('1');


### PR DESCRIPTION
TODO:
- [x] Initialize Secrets at Org creation time
- [x] Update tests to check/verify that Secrets are initialized

SDK now has a Secrets api to simplify loading/caching evergreen runtime secrets in SDK >= 1.1.0.  Need to initialize that when Org is initialized.
