### PR TITLE
Switch to salesforce-sdk 1.1.1

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.1.0"
+version = "1.1.1"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "0.0.2",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -164,9 +164,9 @@
       }
     },
     "@salesforce/salesforce-sdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/salesforce-sdk/-/salesforce-sdk-1.1.0.tgz",
-      "integrity": "sha512-HSHIYZf3c/n8B8UIOsxfCOy/KEmmKTUZBCJGDgj+8FLlUM4x0qdTNfEeFDs+77hPwFSt3nLl78qEofVt/fuIcQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/salesforce-sdk/-/salesforce-sdk-1.1.1.tgz",
+      "integrity": "sha512-UGHVgjb+s0ChguhpWqqEwr1DRsbK9rTkQlxghdiVjvpYEBDZKxRf0AxCSZCEIAvrki1y8jWxZDxocltfv91taA==",
       "requires": {
         "@salesforce/core": "2.1.6",
         "tslib": "1.10.0",
@@ -1582,11 +1582,6 @@
           }
         }
       }
-    },
-    "ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -3111,13 +3106,13 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
       "requires": {
-        "ip-regex": "^2.1.0",
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
       }
     },
     "ts-node": {
@@ -3215,6 +3210,11 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "0.0.2",
+  "version": "1.1.1",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
   },
   "author": "TODO",
   "dependencies": {
-    "@salesforce/salesforce-sdk": "1.1.0",
+    "@salesforce/salesforce-sdk": "^1.1.1",
     "tslib": "1.9.3"
   },
   "devDependencies": {


### PR DESCRIPTION
- Bump sdk version, pin with `^` to allow using latest compatible version rather than exact
- bump buildpack.toml