### PR TITLE
Integrate the evergreen system function

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -57,6 +57,4 @@ else
     cp -r "${MW_LAYER}/dist/." "${DIST_DIR}"
 fi
 
-#set env variable MIDDLEWARE_FUNCTION_URI to the index.js file
-echo -n "$MW_LAYER/dist/index.js" > "$MW_LAYER/env/MIDDLEWARE_FUNCTION_URI"
 echo "launch = true" > "$MW_LAYER.toml"

--- a/bin/detect
+++ b/bin/detect
@@ -16,6 +16,13 @@ if [ -f package.json ]; then
 
   if grep -q "@salesforce/salesforce-sdk" package.json; then
     echo "detected and applying sf-fx-middleware buildpack"
+
+    cat << EOF > "$2"
+  [[requires]]
+  name = "riff-invoker-node"
+  [requires.metadata]
+  fn = "../layers/salesforce_nodejs-fn/middleware/dist"
+EOF
     exit 0
   else
     echo "package does not depend on salesforce-sdk"


### PR DESCRIPTION
## [WIP]

This PR is a substantial change to the existing function architecture, but should be transparent to users. Things this PR is trying to accomplish:

1. Integrate the [system function](https://github.com/heroku/node-function-buildpack/blob/master/system/index.js) (minus the middleware functionality) with this buildpack's context and org injection features.
2. Rely on an unforked and modern version of projectriff/node-function-buildpack.

This has a side-effect that there is no longer a concept of middleware. We're justifying this based on the lack of a use case for the system function without context injection and the inherent type weakness in the middleware API.

This change will mean that we expect a buildpack order like this:

1. heroku/nodejs-engine-buildpack
2. heroku/nodejs-npm-buildpack
3. projectriff/node-function-buildpack
4. forcedotcom/nodejs-sf-fx-buildpack

### TODO
- Read the actual request id from the payload and/or headers instead of a static string.
- Set the request id as context in the logger
- Construct the full `InvocationEvent` by providing the required headers to `createEvent`.
- `npm install` modules from user's `package.json`
- [optional?] Read `package.json` `main` during detect or compile instead of runtime.
- Once published, update `pack-images` to refer to the above list of buildpacks.