### PR TITLE
feat: create NODE_OPTIONS for debugging when in development mode

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -59,4 +59,7 @@ fi
 
 mkdir -p "$MW_LAYER/env.launch"
 echo -n "$MW_LAYER" > "$MW_LAYER/env.launch/FUNCTION_URI.override"
+if [[ ! -z "${DEBUG_PORT}" ]]; then
+  echo -n "--inspect=0.0.0.0:${DEBUG_PORT}" > "$MW_LAYER/env.launch/NODE_OPTIONS.override"
+fi
 echo "launch = true" > "$MW_LAYER.toml"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.4.2"
+version = "1.4.3"
 
 [[stacks]]
 id = "heroku-18"


### PR DESCRIPTION
The builder sets `DEBUG_PORT` when running the `:start` command. We can use that to key off of and automatically emit the `NODE_OPTIONS` with that port so that users can freely debug.

Builder sets the platform env var here: https://github.com/heroku/builder/blob/a160a66cf3510694c45231d93cc7e2a32d25a945/develop/action.go#L270