### PR TITLE
fix: dist.toml corruption during caching

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -37,6 +37,8 @@ if [[ "$local_lock_checksum" == "$cached_lock_checksum" ]] ; then
     cp -r "${NODE_MODULES_DIR}/." "${MW_LAYER}/node_modules"
     cp -r "${DIST_DIR}/." "${MW_LAYER}/dist"
 else
+
+    # Save node_modules.toml
     echo "cache = true" > "${NODE_MODULES_DIR}.toml"
     {
       echo "build = false"
@@ -44,10 +46,13 @@ else
       echo -e "[metadata]\npackage_lock_checksum = \"$local_lock_checksum\""
     } >> "${NODE_MODULES_DIR}.toml"
 
-    # Use the same caching, build, and launch settings as the node_modules.toml
-    # The only time the tsc should be re-ran is if there's been a change to
-    # the package-lock.json file e.g. verion update/new release.
-    cat "${NODE_MODULES_DIR}.toml" >> "${DIST_DIR}.toml"
+    # Save dist.toml
+    echo "cache = true" > "${DIST_DIR}.toml"
+    {
+      echo "build = false"
+      echo "launch = false"
+      echo -e "[metadata]\npackage_lock_checksum = \"$local_lock_checksum\""
+    } >> "${DIST_DIR}.toml"
 
     pushd $MW_LAYER
       npm install --only=production

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.5.0"
+version = "1.5.1"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",


### PR DESCRIPTION
This fixes a bug in the way we were writing cache metadata for the `dist` cache layer.  We were appending to the file causing the `dist.toml` to become corrupt.  For example:
```
build = false
launch = false
cache = true
[metadata]
  package_lock_checksum = "8a7c736358d7f622fa4c037fc8e344ea89d4b4bf1734a67f6011396c98aba84e"
cache = true
build = false
launch = false
[metadata]
package_lock_checksum = "62c6986740a9a15706b93b1c64a6434a7dd663e4b32a985497cc6ba5cc7b647a"
```