### PR TITLE
feat: improve error handling of unhandled user function errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules/
 .project
 .settings
 
+*.tgz

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.5.1"
+version = "1.5.2"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -268,6 +268,11 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@projectriff/message": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@projectriff/message/-/message-1.0.0.tgz",
+      "integrity": "sha512-FXeWHhz5EeMvK/GKb0u0Uvd/nxR8+5PZIUkb62ZU1ym1XLli6PGp0zfDErpNUMkhAulTwyHZWEJlIjWXU51A4A=="
     },
     "@salesforce/core": {
       "version": "2.1.6",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",
@@ -26,6 +26,7 @@
   },
   "author": "TODO",
   "dependencies": {
+    "@projectriff/message": "^1.0.0",
     "@salesforce/salesforce-sdk": "^1.2.0",
     "@types/node": "^10.17.21",
     "tslib": "1.9.3",


### PR DESCRIPTION
When a user function invocation fails and the middleware is forced to intervene, we are now returning a failure result that is in the format of `application/json`.

Outstanding Questions:
1. Is hardcoding to `application/json` right? Should we inspect the `accept` header before assuming `application/json`? What would that even look like to always support `text/plain`?
2. We currently process the middleware, which requires a certain payload shape and does some processing, in the same `try...catch` block. I considered breaking it out and having it throw `400 Bad Request` for any failures inside of that block. Leaving `500`s to mean user code and `400` as likely invocation related. Do we think it makes sense to do that work? Is returning a `500` good enough for now?

Known Issues:
- Content marshalling/unmarshalling by riff is _not_ extensible in any way and always outputs as `text/plain`. So if you send in `{` you will always get back `text/plain` with the error. Reported [here](https://github.com/projectriff/node-function-invoker/issues/211)
- A missing or invalid `package.json` or `index.js` mean the server immediately fails to start. We should try and interrogate the directory and `package.json` in the `build` phase to provide a very clear and fast failure path. This is especially important when you pay the cost of creating an image just to find out you had a typo in your `package.json`. TODO: link GUS ticket

TODO: link GUS ticket for this is somewhere as well