### PR TITLE
Update buildpack [requires] to match updated riff node invoker

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -6,7 +6,7 @@ if [ -f package.json ]; then
 
 cat << EOF > "$2"
 [[requires]]
-name = "riff-invoker-node"
+name = "riff-node"
 
 [requires.metadata]
 fn = "../layers/salesforce_nodejs-fn/middleware/dist"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.5.2"
+version = "1.5.3"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",


### PR DESCRIPTION
The upstream buildpack `[provides]` was changed. We need to update our downstream buildpack to match.

[Requirement](https://github.com/projectriff/node-function-buildpack/blob/v0.6.1/node/detect.go#L37)