### PR TITLE
Precompile JS in buildpack releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 VERSION := "v$$(cat buildpack.toml | grep -m 1 version | sed -e 's/version = //g' | xargs)"
 
-#create a tgz should include the bin and ts source code(to be built to js)
-package: clean
-	@tar cvzf nodejs-sf-fx-buildpack-$(VERSION).tgz buildpack.toml bin/ middleware/*.ts middleware/*.json
+#create a tarball that includes bin, ts source, and compiled js
+package: clean build
+	@tar cvzf nodejs-sf-fx-buildpack-$(VERSION).tgz buildpack.toml bin/ middleware/*.ts middleware/*.json middleware/dist/*.js
 
+#compile middleware ts to js
+build:
+	@cd middleware && npm run build
+
+#remove old tarball
 clean:
 	@rm -f nodejs-sf-fx-buildpack-$(VERSION).tgz

--- a/bin/build
+++ b/bin/build
@@ -13,15 +13,6 @@ NODE_MODULES_DIR="${LAYERS_DIR}/node_modules" # the actual layer where the cachi
 touch "${NODE_MODULES_DIR}.toml"              # the layer toml file that tells lifecycle to enable cache
 mkdir -p "${NODE_MODULES_DIR}"
 
-# Setup caching layer for Typescript dist directory.  Worst case, tsc should only
-# run once.  This middleware is more or less an external library that doesn't need 
-# to be built more than once (maybe never).  The only time it should be rebuilt is
-# after a new version of the middleware has been released e.g. version update to
-# package-lock.json file.
-DIST_DIR="${LAYERS_DIR}/dist"
-touch "${DIST_DIR}.toml"
-mkdir -p "${DIST_DIR}"
-
 # Create directory where ENV vars will be defined
 mkdir -p "$MW_LAYER/env"
 
@@ -35,7 +26,6 @@ cached_lock_checksum=$(yj -t < "${NODE_MODULES_DIR}.toml" | jq -r ".metadata.pac
 if [[ "$local_lock_checksum" == "$cached_lock_checksum" ]] ; then
     echo "using previous node_modules and dist artifacts from cache"
     cp -r "${NODE_MODULES_DIR}/." "${MW_LAYER}/node_modules"
-    cp -r "${DIST_DIR}/." "${MW_LAYER}/dist"
 else
 
     # Save node_modules.toml
@@ -46,20 +36,10 @@ else
       echo -e "[metadata]\npackage_lock_checksum = \"$local_lock_checksum\""
     } >> "${NODE_MODULES_DIR}.toml"
 
-    # Save dist.toml
-    echo "cache = true" > "${DIST_DIR}.toml"
-    {
-      echo "build = false"
-      echo "launch = false"
-      echo -e "[metadata]\npackage_lock_checksum = \"$local_lock_checksum\""
-    } >> "${DIST_DIR}.toml"
-
     pushd $MW_LAYER
       npm install --only=production
-      npm run build
     popd
     cp -r "${MW_LAYER}/node_modules/." "${NODE_MODULES_DIR}"
-    cp -r "${MW_LAYER}/dist/." "${DIST_DIR}"
 fi
 
 mkdir -p "$MW_LAYER/env.launch"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.5.3"
+version = "1.5.4"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -449,7 +449,8 @@
     "@types/node": {
       "version": "10.17.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
-      "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
+      "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ==",
+      "dev": true
     },
     "@types/sinon": {
       "version": "7.5.2",
@@ -3457,7 +3458,8 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.17.1",
@@ -3533,7 +3535,8 @@
     "typescript": {
       "version": "3.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "dev": true
     },
     "underscore": {
       "version": "1.8.3",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -27,10 +27,7 @@
   "author": "TODO",
   "dependencies": {
     "@projectriff/message": "^1.0.0",
-    "@salesforce/salesforce-sdk": "^1.2.0",
-    "@types/node": "^10.17.21",
-    "tslib": "1.9.3",
-    "typescript": "3.4"
+    "@salesforce/salesforce-sdk": "^1.2.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",
@@ -54,6 +51,8 @@
     "request-promise-native": "^1.0.7",
     "rewire": "^5.0.0",
     "sinon": "^7.2.3",
-    "ts-node": "^8.9.0"
+    "ts-node": "^8.9.0",
+    "tslib": "1.9.3",
+    "typescript": "3.4"
   }
 }


### PR DESCRIPTION
This PR aims to improve build performance and slim runtime dependencies for function builds. By compiling JS on buildpack release instead of during builds, we gain these benefits:

- Typescript is not installed. We save the installation costs in both build time and overall image size.
- We're no longer compiling the middleware. We save build time here, and also save time and storage by not caching the compiled artifacts.
