### PR TITLE
fix: update metadata key from fn to artifact

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -9,7 +9,7 @@ cat << EOF > "$2"
 name = "riff-node"
 
 [requires.metadata]
-fn = "../layers/salesforce_nodejs-fn/middleware/dist"
+artifact = "../layers/salesforce_nodejs-fn/middleware/dist"
 EOF
   exit 0
 fi

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.5.4"
+version = "1.5.5"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",


### PR DESCRIPTION
The latest riff update meant we are accidentally skipping the middleware. Fix is to reference the expected middleware as the riff target.

[Example](https://github.com/projectriff/node-function-buildpack/blob/532653d2857e003482d4e9cf890b3e240cc17c9a/node/build_test.go#L57)

Found failure here: https://app.circleci.com/pipelines/github/heroku/evergreen-plugin-build/606/workflows/56140e94-1fe3-4e84-91f2-4c8eae043e8a/jobs/2314/steps

The `FUNCTION_URI` was `/workspace` (default) instead of `/layers/salesforce_nodejs-fn/middleware/dist`