### PR TITLE
feat: load user defined function during build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -16,7 +16,7 @@ mkdir -p "${NODE_MODULES_DIR}"
 # Create directory where ENV vars will be defined
 mkdir -p "$MW_LAYER/env"
 
-#BP_DIR has all the files that's untared from the buildpack targz 
+#BP_DIR has all the files that's untared from the buildpack targz
 #copy all the source files to MW_LAYER folder
 cp -a "$BP_DIR/middleware/." $MW_LAYER
 
@@ -47,3 +47,6 @@ if [[ ! -z "${DEBUG_PORT}" ]]; then
   echo -n "--inspect=0.0.0.0:${DEBUG_PORT}" > "$MW_LAYER/env.launch/NODE_OPTIONS.override"
 fi
 echo "launch = true" > "$MW_LAYER.toml"
+
+# test that we can load the user function
+echo "require('$MW_LAYER/dist/userFnLoader').default()" | node

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.5.5"
+version = "1.5.6"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",

--- a/middleware/userFnLoader.ts
+++ b/middleware/userFnLoader.ts
@@ -1,0 +1,23 @@
+import * as path from "path";
+
+export default function loadUserFunction(): any {
+  const functionPath = process.env.USER_FUNCTION_URI || '/workspace';
+  const pjsonPath = path.join(functionPath, 'package.json');
+  let main;
+  try {
+    main = require(pjsonPath).main;
+  } catch (e) {
+    throw `Could not read package.json: ${e}`;
+  }
+  const mainPath = path.join(functionPath, main);
+  let mod;
+  try {
+    mod = require(mainPath);
+  } catch (e) {
+    throw `Could not locate user function: ${e}`;
+  }
+  if (mod.__esModule && typeof mod.default === 'function') {
+    return mod.default;
+  }
+  return mod;
+}


### PR DESCRIPTION
By `require(userFn)` during the build phase, we can detect invalid `package.json` and invalid `main: "yourfile.js"` values. This does mean we pay the cost of `require` of the user function and its dependencies during build. It also means that code outside of the function may execute during `require`. If, say, a user were to code in database migrations or something dangerous in their `index.js` that code would be attempted during the build's `require` instead of on function pod start. I'm not sure we have any guidelines past what the funciton should look like today.

Here is what an invalid `main` value looks like.
![image](https://user-images.githubusercontent.com/790999/84831099-59185480-aff0-11ea-83d6-1597c4aacd4f.png)

[W-7659608](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008D5iPIAS/view)