### PR TITLE
Bump to latest sf-fx-sdk-nodejs version, prepare for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ node_modules/
 .settings
 
 *.tgz
+/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ node_modules/
 .settings
 
 *.tgz
-/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM heroku/functions-buildpacks
+ADD nodejs-sf-fx-buildpack-v1.5.6.tgz /cnb/buildpacks/salesforce_nodejs-fn/1.5.6

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.5.6"
+version = "1.5.7"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -302,16 +302,16 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
         }
       }
     },
     "@salesforce/salesforce-sdk": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/salesforce-sdk/-/salesforce-sdk-1.2.0.tgz",
-      "integrity": "sha512-Sth8wtGHD2murbntCSoMUPfgYcJU/azvkf26gOV9xr5nJnpy9G8NEcBjXMf13APlpYXqFmlz9Lp1z2DOGXA7FA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/salesforce-sdk/-/salesforce-sdk-1.3.0.tgz",
+      "integrity": "sha512-BSa+A2GcgWf5/9/1QTdXeeSFI1gjBS7y5Xjbscw9oKPRbK92QSvK0imDR14TGpxmBu24goncLI1MYYOSw6qopg==",
       "requires": {
         "@salesforce/core": "2.1.6",
         "tslib": "1.10.0",
@@ -350,9 +350,9 @@
           }
         },
         "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
         }
       }
     },
@@ -365,9 +365,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
         }
       }
     },
@@ -1018,9 +1018,9 @@
       }
     },
     "csv-parse": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.9.1.tgz",
-      "integrity": "sha512-DSoBx9V5PpAVWZbqqYKaoxYsf6yQdltTlUmZ1gPjvoTeRI5wPDlwa6ovrmeUP/1y4MjUkAPXx17aPlu0E6xBvg=="
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.10.1.tgz",
+      "integrity": "sha512-gdDJVchi0oSLIcYXz1H/VSgLE6htHDqJyFsRU/vTkQgmVOZ3S0IR2LXnNbWUYG7VD76dYVwdfBLyx8AX9+An8A=="
     },
     "csv-stringify": {
       "version": "1.1.2",
@@ -1343,13 +1343,14 @@
       "dev": true
     },
     "faye": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/faye/-/faye-1.2.5.tgz",
-      "integrity": "sha512-0wc9n6YxziRr1oPLsPF1JCzA5EK5y8+fw0MhhNNm/9reIMbwvhwyIJ/686A6j9WnUGLx3JrCm0m3SRfn2hRRjA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/faye/-/faye-1.3.0.tgz",
+      "integrity": "sha512-l+IzAmEsT2OCVeGbLfZBpm8HeHQYVelkqKWNE0LA/k68jhVIT/qzHTXLygURrLpKweqiaTBCtzxxO5JTQ+dnFQ==",
       "requires": {
         "asap": "*",
         "csprng": "*",
         "faye-websocket": ">=0.9.1",
+        "safe-buffer": "*",
         "tough-cookie": "*",
         "tunnel-agent": "*"
       }
@@ -1646,9 +1647,9 @@
       "dev": true
     },
     "http-parser-js": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.2.tgz",
+      "integrity": "sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2397,9 +2398,9 @@
       }
     },
     "moment": {
-      "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
-      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
       "optional": true
     },
     "ms": {
@@ -3583,19 +3584,19 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
-      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
       "requires": {
-        "http-parser-js": ">=0.4.0 <0.4.11",
+        "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
         "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
     "which": {
       "version": "1.3.1",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -27,7 +27,7 @@
   "author": "TODO",
   "dependencies": {
     "@projectriff/message": "^1.0.0",
-    "@salesforce/salesforce-sdk": "^1.2.0"
+    "@salesforce/salesforce-sdk": "^1.3.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",


### PR DESCRIPTION
* latest sf-fx-sdk-nodejs release (https://github.com/forcedotcom/sf-fx-sdk-nodejs/releases/tag/v1.3.0), backward compatible with 1.2.0 and 1.1.x
* bump buildpack.toml version 
