### PR TITLE
Support CloudEvents v1.0 spec, in addition to v0.2

### DIFF
--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {Logger, LoggerLevel} from '@salesforce/core/lib/logger';
 const {Message} = require('@projectriff/message');
 const http = require('http');
@@ -44,7 +46,7 @@ function errorMessage(error: Error): any {
         .build();
 }
 
-function isAsyncRequest(type: string) {
+function isAsyncRequest(type: string): boolean {
     return type && type.startsWith(ASYNC_CE_TYPE);
 }
 

--- a/middleware/lib/sfMiddleware.ts
+++ b/middleware/lib/sfMiddleware.ts
@@ -30,10 +30,19 @@ function headersToMap(headers: any = {}): ReadonlyMap<string, ReadonlyArray<stri
  * @return event
  */
 function createEvent(data: any, headers: any, payload: any): InvocationEvent {
+    const specVersion = payload.specversion ? payload.specversion : payload.specVersion;
+    const schemaURL = specVersion === "0.2" ? payload.schemaURL : null;
+    let contentType;
+    if (specVersion === "0.2") {
+        contentType = payload.contentType ? payload.contentType : payload.contenttype;
+    }
+    else {
+        contentType = payload.datacontenttype;
+    }
     return new InvocationEvent(
         data,
-        payload.contentType,
-        payload.schemaURL,
+        contentType,
+        schemaURL,
         payload.id,
         payload.source,
         payload.time,

--- a/middleware/lib/sfMiddleware.ts
+++ b/middleware/lib/sfMiddleware.ts
@@ -31,9 +31,9 @@ function headersToMap(headers: any = {}): ReadonlyMap<string, ReadonlyArray<stri
  */
 function createEvent(data: any, headers: any, payload: any): InvocationEvent {
     const specVersion = payload.specversion ? payload.specversion : payload.specVersion;
-    const schemaURL = specVersion === "0.2" ? payload.schemaURL : null;
+    const schemaURL = specVersion === '0.2' ? payload.schemaURL : null;
     let contentType;
-    if (specVersion === "0.2") {
+    if (specVersion === '0.2') {
         contentType = payload.contentType ? payload.contentType : payload.contenttype;
     }
     else {

--- a/middleware/lib/sfMiddleware.ts
+++ b/middleware/lib/sfMiddleware.ts
@@ -199,8 +199,8 @@ export function applySfFnMiddleware(request: any, logger: Logger): Array<any> {
     if (!data) {
         throw new Error('Data field of the cloudEvent not provided in the request');
     }
-    const ceCtx = isSpec02 ? data.context : decodeCeAttrib(ceBody['sfcontext']);
-    const ceFnCtx = isSpec02 ? data.sfContext : decodeCeAttrib(ceBody['sffncontext']);
+    const ceCtx = isSpec02 ? data.context : decodeCeAttrib(ceBody.sfcontext);
+    const ceFnCtx = isSpec02 ? data.sfContext : decodeCeAttrib(ceBody.sffncontext);
     if (!ceCtx) {
         logger.warn('Context not provided in data: context is partially initialize');
     }

--- a/middleware/test/unit/ContextTests.ts
+++ b/middleware/test/unit/ContextTests.ts
@@ -60,6 +60,7 @@ describe('Context Tests', () => {
         expect(event.type).to.not.be.undefined;
         expect(event.source).to.not.be.undefined;
         expect(event.dataContentType).to.not.be.undefined;
+        expect(event.dataContentType).to.equal('application/json');
         expect(event.dataSchema).to.not.be.undefined;
         expect(event.data).to.not.be.undefined;
         expect(event.headers).to.not.be.undefined;

--- a/middleware/test/unit/FunctionTestUtils.ts
+++ b/middleware/test/unit/FunctionTestUtils.ts
@@ -55,17 +55,30 @@ export const generateData = (setAccessToken = true, setOnBehalfOfUserId = false,
     return data;
 };
 
-export const generateCloudevent = (data: any, async = false): any => {
-    return {
-        id: '00Dxx0000006GY7-4SROyqmXwNJ3M40_wnZB1k',
-        contentType: 'application/json',
-        type: async ? ASYNC_CE_TYPE : 'com.salesforce.function.invoke',
-        schemaURL: null,
-        source: 'urn:event:from:salesforce/xx/224.0/00Dxx0000006GY7/InvokeFunctionController/9mdxx00000004ov',
-        time: '2019-11-14T18:13:45.627813Z',
-        specVersion: '0.2',
-        data
-    };
+export const generateCloudevent = (data: any, async = false, specVersion = '0.2'): any => {
+    if (specVersion === '0.2') {
+        return {
+            id: '00Dxx0000006GY7-4SROyqmXwNJ3M40_wnZB1k',
+            contentType: 'application/json',
+            type: async ? ASYNC_CE_TYPE : 'com.salesforce.function.invoke',
+            schemaURL: null,
+            source: 'urn:event:from:salesforce/xx/224.0/00Dxx0000006GY7/InvokeFunctionController/9mdxx00000004ov',
+            time: '2019-11-14T18:13:45.627813Z',
+            specVersion: specVersion,
+            data
+        };
+    }
+    else {
+        return {
+            id: '00Dxx0000006GY7-4SROyqmXwNJ3M40_wnZB1k',
+            contenttype: 'application/json',
+            type: async ? ASYNC_CE_TYPE : 'com.salesforce.function.invoke',
+            source: 'urn:event:from:salesforce/xx/224.0/00Dxx0000006GY7/InvokeFunctionController/9mdxx00000004ov',
+            time: '2019-11-14T18:13:45.627813Z',
+            specversion: specVersion,
+            data
+        };
+    }
 };
 
 export const generateRawMiddleWareRequest = (data: any, async = false): any => {

--- a/middleware/test/unit/FunctionTestUtils.ts
+++ b/middleware/test/unit/FunctionTestUtils.ts
@@ -81,7 +81,7 @@ export const generateCloudevent = (data: any, async = false, specVersion = '0.2'
         // base64-encoded-json extension attributes.
         return {
             id: '00Dxx0000006GY7-4SROyqmXwNJ3M40_wnZB1k',
-            contenttype: 'application/json',
+            datacontenttype: 'application/json',
             type: async ? ASYNC_CE_TYPE : 'com.salesforce.function.invoke',
             source: 'urn:event:from:salesforce/xx/224.0/00Dxx0000006GY7/InvokeFunctionController/9mdxx00000004ov',
             time: '2019-11-14T18:13:45.627813Z',


### PR DESCRIPTION
We need to handle both v0.2 and v1.0 of the CloudEvents spec for backwards compatibility:

https://github.com/cloudevents/spec/blob/v0.2/spec.md
https://github.com/cloudevents/spec/blob/v1.0/spec.md