### PR TITLE
fix: support missing main key in package.json

### DIFF
--- a/middleware/userFnLoader.ts
+++ b/middleware/userFnLoader.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 export default function loadUserFunction(): any {
   const functionPath = process.env.USER_FUNCTION_URI || '/workspace';
   const pjsonPath = path.join(functionPath, 'package.json');
-  let main;
+  let main = '';
   try {
     main = require(pjsonPath).main;
   } catch (e) {


### PR DESCRIPTION
Without a `main` key in `package.json`, the loading of the user function fails. This is due to the `main` variable remaining `undefined` and `path.join` failing. By defaulting to empty string, the `path.join` will no longer fail. This will allow folder-level import of the user function.