### PR TITLE
Handle full matrix of CloudEvents formats: 0.3 vs 1.0, structured json vs HTTP binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ node_modules/
 .classpath
 .project
 .settings
+.vscode
 
 *.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM heroku/functions-buildpacks
-ADD nodejs-sf-fx-buildpack-v1.6.0.tgz /cnb/buildpacks/salesforce_nodejs-fn/1.6.0
+ADD nodejs-sf-fx-buildpack-v1.6.1.tgz /cnb/buildpacks/salesforce_nodejs-fn/1.6.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,17 @@
 FROM heroku/functions-buildpacks
-ADD nodejs-sf-fx-buildpack-v1.6.1.tgz /cnb/buildpacks/salesforce_nodejs-fn/1.6.1
+
+# Need to specify --build-arg 1.x.x at build time
+ARG FNVERS=0.0.0
+
+ADD nodejs-sf-fx-buildpack-v${FNVERS}.tgz /cnb/buildpacks/salesforce_nodejs-fn/${FNVERS}
+
+USER root
+RUN set -xe && \
+    cd /cnb/buildpacks/evergreen_fn/ && \
+    cd $(/bin/ls -1 | egrep '^[0-9][0-9.]*') && \
+    sed -i -e '/salesforce[/]nodejs-fn/{n;d;}' buildpack.toml && \
+    echo '    version = "'${FNVERS}'"' >> buildpack.toml && \
+    cat buildpack.toml && \
+    true
+USER heroku
+

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ VERSION := "v$$(cat buildpack.toml | grep -m 1 version | sed -e 's/version = //g
 package: clean build
 	@tar cvzf nodejs-sf-fx-buildpack-$(VERSION).tgz buildpack.toml bin/ middleware/*.ts middleware/*.json middleware/dist/*.js middleware/dist/lib/*.js
 
+#create a docker image that includes above buildpack
+image: package
+	@docker build -t nodejs-sf-fx-buildpacks:latest --build-arg FNVERS=`echo $(VERSION) | sed 's/^v//'` --no-cache .
+
 #compile middleware ts to js
 build:
 	@cd middleware && npm run build

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.6.0"
+version = "1.6.1"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -145,13 +145,15 @@ function parseCloudEvent(logger: Logger, headers: Map<string,string>, body: any)
         _mv(body, 'schemaURL', 'schemaurl');
         headers['content-type'] = 'application/cloudevents+json';
         logger.info('Translated cloudevent 0.2 to 0.3 format');
-    // Initial deployment of Core API 50.0 send the wrong content-type, need to adjust
+
+        // Initial deployment of Core API 50.0 send the wrong content-type, need to adjust
     } else if (ctype.includes('application/json') && 'specversion' in body) {
         headers['content-type'] = 'application/cloudevents+json';
         logger.info('Forced content-type to: application/cloudevents+json');
     }
+
     // make a clone of the body - cloudevents sdk deletes keys as it parses
-    return httpReceiver.accept(headers, Object.create(body));
+    return httpReceiver.accept(headers, Object.assign({}, body));
 }
 
 const userFn = loadUserFunction();

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -199,7 +199,7 @@ export default async function systemFn(message: any): Promise<any> {
         }
     } catch (error) {
         requestLogger.error(error.toString());
-        return errorMessage(error)
+        return errorMessage(error);
     }
 }
 

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -169,7 +169,8 @@ export default async function systemFn(message: any): Promise<any> {
     try {
         cloudEvent = parseCloudEvent(requestLogger, headers, bodyPayload);
     } catch(parseErr) {
-        requestLogger.fatal(`Failed to parse CloudEvent content-type=${headers['content-type']} body=${JSON.stringify(bodyPayload)}`);
+        // Only log toplevel input keys since values can contain credentials or PII
+        requestLogger.fatal(`Failed to parse CloudEvent content-type=${headers['content-type']} body keys=${Object.keys(bodyPayload)}`);
         requestLogger.fatal(parseErr);
         return Message.builder()
             .addHeader('content-type', 'application/json')

--- a/middleware/lib/sfMiddleware.ts
+++ b/middleware/lib/sfMiddleware.ts
@@ -194,7 +194,7 @@ export function applySfFnMiddleware(cloudEvent: CloudEvent, headers: ReadonlyMap
         throw new Error('Data field of the cloudEvent not provided in the request');
     }
     const ceCtx = isSpec1 ? decodeCeAttrib(cloudEvent.getExtensions()['sfcontext']) : data.context;
-    const ceFnCtx = isSpec1  ?decodeCeAttrib(cloudEvent.getExtensions()['sffncontext']) : data.sfContext;
+    const ceFnCtx = isSpec1 ? decodeCeAttrib(cloudEvent.getExtensions()['sffncontext']) : data.sfContext;
     if (!ceCtx) {
         logger.warn('Context not provided in data: context is partially initialized');
     }

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -2154,9 +2154,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -294,19 +294,12 @@
       }
     },
     "@salesforce/kit": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-1.2.2.tgz",
-      "integrity": "sha512-MQXUh8Ka8oB1SOPUF1kOynXQWcLeZ8YWOyqPtg6j8U9NxLlkTF2vfUfhZEm//jXjejDy7CEes5rEKRHm2df/OA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-1.3.2.tgz",
+      "integrity": "sha512-Fhzl4pzk1z0B3CAbo+RfzZ5iwtc85Hpdx6CFctIdpPmB8Y1RRF7HByFRf3NYWHEYggfPmPutkwj4IZfpOcJaiQ==",
       "requires": {
-        "@salesforce/ts-types": "^1.2.2",
+        "@salesforce/ts-types": "^1.4.2",
         "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
       }
     },
     "@salesforce/salesforce-sdk": {
@@ -327,23 +320,15 @@
       }
     },
     "@salesforce/ts-sinon": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-sinon/-/ts-sinon-1.1.3.tgz",
-      "integrity": "sha512-XWwX3wavhMfS5J4jbWSItQO9HQ6eNesSbLpAPYSQiCN/6xLtcN0ohFDUMm6bZae6TFTavczCRy6ACFMt+XtxJg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-sinon/-/ts-sinon-1.2.2.tgz",
+      "integrity": "sha512-nzdkQeD5MHKkRrz8V8CvcY42cX7L2jsA3iog9iMEMgepp+5OP6zEoIk2XehtbaAzu6B8B5tr7FNu+GfGMIVt+g==",
       "requires": {
-        "@salesforce/ts-types": "^1.3.0",
+        "@salesforce/ts-types": "^1.4.2",
         "sinon": "5.1.1",
         "tslib": "^1.10.0"
       },
       "dependencies": {
-        "@salesforce/ts-types": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.3.0.tgz",
-          "integrity": "sha512-ZJiDhvBnJO6mqkPsVDxfmrZAYmI27I/6bcRSbyzvtREzFux1lit3rhgcKyDUh+/9mrphJNFzRUiuWI4p3phhXA==",
-          "requires": {
-            "tslib": "^1.10.0"
-          }
-        },
         "sinon": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
@@ -361,18 +346,11 @@
       }
     },
     "@salesforce/ts-types": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.2.2.tgz",
-      "integrity": "sha512-inTkNP5jwJTbKqmBv6Cku/ezU6+ErYbUH4YorDfgZ/wDCsdLc9UyPGKGMO8aZ78vvyUTYWEiDxWlMqb1QXEfEw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.4.2.tgz",
+      "integrity": "sha512-JxLK/XBv64Nq8llDCJYXn+lR4MNONatCeI+wu/7ac+NiHdsj7xCGjtZ743H0/mxRnsVqEnZzpSJDrxo2OHVbzw==",
       "requires": {
         "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-          "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-        }
       }
     },
     "@sinonjs/commons": {
@@ -1002,9 +980,9 @@
       }
     },
     "csv-parse": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.10.1.tgz",
-      "integrity": "sha512-gdDJVchi0oSLIcYXz1H/VSgLE6htHDqJyFsRU/vTkQgmVOZ3S0IR2LXnNbWUYG7VD76dYVwdfBLyx8AX9+An8A=="
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.11.1.tgz",
+      "integrity": "sha512-cH2BG5Gd0u4G8qVI/jGXJSP2+El7Vy91/ZD3ehKALAWids1aIKOPhZ1ZVJzUrs2zTn6aGumVPBlbHsI91kI83A=="
     },
     "csv-stringify": {
       "version": "1.1.2",

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -689,6 +689,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -859,6 +867,23 @@
           "requires": {
             "ansi-regex": "^5.0.0"
           }
+        }
+      }
+    },
+    "cloudevents-sdk": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/cloudevents-sdk/-/cloudevents-sdk-2.0.2.tgz",
+      "integrity": "sha512-sXTYWUFbUYg75b+71MH7AhHsEC4iCdlxf4W9flveRbih6xSDOuLryWbCuBZpeO1iLrt5uT1gD1flB38RhVSVBQ==",
+      "requires": {
+        "ajv": "~6.12.0",
+        "axios": "~0.19.2",
+        "uuid": "~8.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
         }
       }
     },
@@ -1453,6 +1478,29 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "foreground-child": {
       "version": "2.0.0",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -27,7 +27,8 @@
   "author": "TODO",
   "dependencies": {
     "@projectriff/message": "^1.0.0",
-    "@salesforce/salesforce-sdk": "^1.3.0"
+    "@salesforce/salesforce-sdk": "^1.3.0",
+    "cloudevents-sdk": "^2.0.2"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",

--- a/middleware/test/unit/ContextTests.ts
+++ b/middleware/test/unit/ContextTests.ts
@@ -77,9 +77,9 @@ describe('Context Tests', () => {
     };
 
     const getContext = (data: any) : Context => {
-        const rawRequest = generateRawMiddleWareRequest(data);
+        const [cloudEvent, headers] = generateRawMiddleWareRequest(data);
         const logger = new Logger('Evergreen Logger Context Unit Test');
-        const mwResult: any = applySfFnMiddleware(rawRequest, logger);
+        const mwResult: any = applySfFnMiddleware(cloudEvent, headers, logger);
         validateApplyMiddleWareResult(data, mwResult);
 
         const context: Context = mwResult[1] as Context;
@@ -207,9 +207,9 @@ describe('Context Tests', () => {
         const data = generateData(true);
         expect(data.context).to.exist;
 
-        const rawRequest = generateRawMiddleWareRequest(data);
+        const [cloudEvent, headers] = generateRawMiddleWareRequest(data);
         const logger = new Logger('Evergreen Logger Context Unit Test');
-        const mwResult: any = applySfFnMiddleware(rawRequest, logger);
+        const mwResult: any = applySfFnMiddleware(cloudEvent, headers, logger);
         validateApplyMiddleWareResult(data, mwResult);
 
         const context: Context = mwResult[1] as Context;
@@ -228,9 +228,9 @@ describe('Context Tests', () => {
         const data = generateData(true);
         expect(data.context).to.exist;
 
-        const rawRequest = generateRawMiddleWareRequest(data);
+        const [cloudEvent, headers] = generateRawMiddleWareRequest(data);
         const logger = new Logger('Evergreen Logger Context Unit Test');
-        const mwResult: any = applySfFnMiddleware(rawRequest, logger);
+        const mwResult: any = applySfFnMiddleware(cloudEvent, headers, logger);
         validateApplyMiddleWareResult(data, mwResult);
 
         const context: Context = mwResult[1] as Context;
@@ -241,9 +241,9 @@ describe('Context Tests', () => {
 
     it('expect custom payload data not available', () => {
         const data = {"someproperty":"whatever"};
-        const rawRequest = generateRawMiddleWareRequest(data);
+        const [cloudEvent, headers] = generateRawMiddleWareRequest(data);
         const logger = new Logger('Evergreen Logger Context Unit Test');
-        const mwResult: any = applySfFnMiddleware(rawRequest, logger);
+        const mwResult: any = applySfFnMiddleware(cloudEvent, headers, logger);
 
         expect(mwResult).to.be.an('array');
         expect(mwResult).to.have.lengthOf(3);

--- a/middleware/test/unit/ContextTests.ts
+++ b/middleware/test/unit/ContextTests.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {LoggerLevel} from '@salesforce/core';
 import {ConnectionConfig, Constants, Context, Logger} from '@salesforce/salesforce-sdk';
 import {expect} from 'chai';
@@ -21,7 +22,7 @@ describe('Context Tests', () => {
         sandbox.restore();
     });
 
-    const validateContext = (data: any, context: Context, hasOnBehalfOfUserId = false) => {
+    const validateContext = (data: any, context: Context, hasOnBehalfOfUserId = false): void => {
         expect(context.org.apiVersion).to.exist;
         expect(context.org.apiVersion).to.equal(Constants.CURRENT_API_VERSION);
 
@@ -48,7 +49,7 @@ describe('Context Tests', () => {
      * @param expectedPayload
      * @param middlewareResult
      */
-    const validateApplyMiddleWareResult = (data: any, middlewareResult : any) => {
+    const validateApplyMiddleWareResult = (data: any, middlewareResult : any): void => {
         expect(middlewareResult).to.be.an('array');
         expect(middlewareResult).to.have.lengthOf(3);
         expect(middlewareResult[0]).to.exist;
@@ -185,7 +186,7 @@ describe('Context Tests', () => {
         const fsStat = new fs.Stats();
         sandbox.stub(fsStat, 'isDirectory').returns(true);
         sandbox.stub(fsStat, 'isFile').returns(true);
-        const statSyncOrig = fs.statSync;
+
         // Using callsFake here as this repo uses later version of fs.statSync having an API update
         // which now conflicts w/ the SDK's version.
         sandbox.stub(fs, 'statSync').callsFake((path) => {

--- a/middleware/test/unit/InvokeTests.ts
+++ b/middleware/test/unit/InvokeTests.ts
@@ -1,4 +1,5 @@
-/* tslint:disable: no-unused-expression */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-var-requires */
 import { assert, expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import 'mocha';
@@ -285,10 +286,10 @@ describe('Invoke Function Tests', () => {
             saveFnInvocationStub.callsFake(async (logger: Logger,
                 fnInvocation: fnInvRequest.FunctionInvocationRequest,
                 response: any,
-                status): Promise<void> => {
+                status): Promise<void> => {  // eslint-disable-line @typescript-eslint/no-unused-vars
                     gotFnInvocation = fnInvocation;
                     gotResponse = response;
-                    return Promise.resolve(null)
+                    return Promise.resolve(null);
             });
 
             const cloudEventRequest = generateCloudevent(generateData(), true, specVersion);
@@ -315,7 +316,7 @@ describe('Invoke Function Tests', () => {
                 response: any): Promise<void> => {
                     gotFnInvocation = fnInvocation;
                     gotResponse = response;
-                    return Promise.resolve(null)
+                    return Promise.resolve(null);
             });
 
             const cloudEventRequest = generateCloudevent(generateData(true, false, true), true, specVersion);
@@ -336,5 +337,5 @@ describe('Invoke Function Tests', () => {
 
             return Promise.resolve(null);
         });
-    })
+    });
 });

--- a/middleware/tsconfig.json
+++ b/middleware/tsconfig.json
@@ -6,7 +6,8 @@
         "rootDir": "./",
         "target": "es2017",
         "lib": [
-            "es2017"
+            "es2017",
+            "dom"
         ],
         "sourceMap": true,
         "declaration": true,

--- a/middleware/userFnLoader.ts
+++ b/middleware/userFnLoader.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as path from "path";
 
 export default function loadUserFunction(): any {


### PR DESCRIPTION
Fix crashes in middleware 1.6.0 via
- Using cloudevents-sdk to validate and parse incoming cloudevent in any of its supported HTTP formats
  . because evergreen:function:invoke uses HTTP binary 0.3 by default, core 226 uses json structured 0.3, core 228 will use json structure 1.0

TODO:
- [x] update async invocation to use cloudevents-sdk to serialize/request
- [x] update tests
- [x] test deployed function w/this middleware against 226 org
- [x] test against 228 org
- [x] drop WIP tag once TODOs are solved

