### PR TITLE
Install user's function as a node module

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -43,12 +43,11 @@ else
 fi
 
 pushd $MW_LAYER
-  echo "Installing /workspace"
   npm install /workspace
 popd
 
 FUNCTION_PACKAGE_NAME=$(jq -r '.name' < /workspace/package.json)
-echo -n "$FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/FUNCTION_PACKAGE_NAME"
+echo -n "$FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/FUNCTION_PACKAGE_NAME.override"
 
 mkdir -p "$MW_LAYER/env.launch"
 if [[ ! -z "${DEBUG_PORT}" ]]; then
@@ -59,4 +58,4 @@ echo "launch = true" > "$MW_LAYER.toml"
 
 # test that we can load the user function
 cd $MW_LAYER
-echo "require('$FUNCTION_PACKAGE_NAME')" | node
+echo "require('$FUNCTION_PACKAGE_NAME').default()" | node

--- a/bin/build
+++ b/bin/build
@@ -42,11 +42,16 @@ else
     cp -r "${MW_LAYER}/node_modules/." "${NODE_MODULES_DIR}"
 fi
 
+npm install /workspace
+FUNCTION_PACKAGE_NAME=$(jq -r '.name' < /workspace/package.json)
+echo -n "$FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/FUNCTION_PACKAGE_NAME"
+
 mkdir -p "$MW_LAYER/env.launch"
 if [[ ! -z "${DEBUG_PORT}" ]]; then
   echo -n "--inspect=0.0.0.0:${DEBUG_PORT}" > "$MW_LAYER/env.launch/NODE_OPTIONS.override"
 fi
 echo "launch = true" > "$MW_LAYER.toml"
+
 
 # test that we can load the user function
 echo "require('$MW_LAYER/dist/userFnLoader').default()" | node

--- a/bin/build
+++ b/bin/build
@@ -44,11 +44,16 @@ fi
 
 # Setup user function as a node module dependency in the middleware and allow
 # the user function to be required by name.
-SF_FUNCTION_PACKAGE_NAME=$(jq -r '.name' < /workspace/package.json)
+SF_FUNCTION_PACKAGE_NAME=$(jq -r '.name // empty' < /workspace/package.json)
 if [[ -z "${SF_FUNCTION_PACKAGE_NAME}" ]]; then
-  echo "Salesforce function package name not defined. Does the package.json have a 'name'?"
+  echo "Salesforce function package name not defined. Make sure there is a 'name' in package.json."
   exit 1
 fi
+if [[ -d "$MW_LAYER/node_modules/$SF_FUNCTION_PACKAGE_NAME" ]]; then
+  echo "Salesforce function package name($SF_FUNCTION_PACKAGE_NAME) conflicts with existing module. Change the 'name' in package.json."
+  exit 1
+fi
+echo "Installing $SF_FUNCTION_PACKAGE_NAME"
 echo -n "$SF_FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/SF_FUNCTION_PACKAGE_NAME.override"
 ln -s /workspace "$MW_LAYER/node_modules/$SF_FUNCTION_PACKAGE_NAME"
 

--- a/bin/build
+++ b/bin/build
@@ -42,7 +42,11 @@ else
     cp -r "${MW_LAYER}/node_modules/." "${NODE_MODULES_DIR}"
 fi
 
-npm install /workspace
+pushd $MW_LAYER
+  echo "Installing /workspace"
+  npm install /workspace
+popd
+
 FUNCTION_PACKAGE_NAME=$(jq -r '.name' < /workspace/package.json)
 echo -n "$FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/FUNCTION_PACKAGE_NAME"
 
@@ -54,4 +58,5 @@ echo "launch = true" > "$MW_LAYER.toml"
 
 
 # test that we can load the user function
-echo "require('$MW_LAYER/dist/userFnLoader').default()" | node
+cd $MW_LAYER
+echo "require('$FUNCTION_PACKAGE_NAME')" | node

--- a/bin/build
+++ b/bin/build
@@ -42,12 +42,11 @@ else
     cp -r "${MW_LAYER}/node_modules/." "${NODE_MODULES_DIR}"
 fi
 
-pushd $MW_LAYER
-  npm install /workspace
-popd
-
-FUNCTION_PACKAGE_NAME=$(jq -r '.name' < /workspace/package.json)
-echo -n "$FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/FUNCTION_PACKAGE_NAME.override"
+# Setup user function as a node module dependency in the middleware and allow
+# the user function to be required by name.
+USER_FUNCTION_PACKAGE_NAME=$(jq -r '.name' < /workspace/package.json)
+echo -n "$USER_FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/USER_FUNCTION_PACKAGE_NAME.override"
+ln -s /workspace "$MW_LAYER/node_modules/$USER_FUNCTION_PACKAGE_NAME"
 
 mkdir -p "$MW_LAYER/env.launch"
 if [[ ! -z "${DEBUG_PORT}" ]]; then
@@ -57,5 +56,4 @@ echo "launch = true" > "$MW_LAYER.toml"
 
 
 # test that we can load the user function
-cd $MW_LAYER
-echo "require('$FUNCTION_PACKAGE_NAME').default()" | node
+echo "require('$MW_LAYER/dist/userFnLoader').default()" | USER_FUNCTION_PACKAGE_NAME=$USER_FUNCTION_PACKAGE_NAME node

--- a/bin/build
+++ b/bin/build
@@ -54,6 +54,5 @@ if [[ ! -z "${DEBUG_PORT}" ]]; then
 fi
 echo "launch = true" > "$MW_LAYER.toml"
 
-
 # test that we can load the user function
-echo "require('$MW_LAYER/dist/userFnLoader').default()" | SF_FUNCTION_PACKAGE_NAME=$SF_FUNCTION_PACKAGE_NAME node
+echo "require('$MW_LAYER/dist/userFnLoader').default('$SF_FUNCTION_PACKAGE_NAME')" | node

--- a/bin/build
+++ b/bin/build
@@ -44,9 +44,9 @@ fi
 
 # Setup user function as a node module dependency in the middleware and allow
 # the user function to be required by name.
-USER_FUNCTION_PACKAGE_NAME=$(jq -r '.name' < /workspace/package.json)
-echo -n "$USER_FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/USER_FUNCTION_PACKAGE_NAME.override"
-ln -s /workspace "$MW_LAYER/node_modules/$USER_FUNCTION_PACKAGE_NAME"
+SF_FUNCTION_PACKAGE_NAME=$(jq -r '.name' < /workspace/package.json)
+echo -n "$SF_FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/SF_FUNCTION_PACKAGE_NAME.override"
+ln -s /workspace "$MW_LAYER/node_modules/$SF_FUNCTION_PACKAGE_NAME"
 
 mkdir -p "$MW_LAYER/env.launch"
 if [[ ! -z "${DEBUG_PORT}" ]]; then
@@ -56,4 +56,4 @@ echo "launch = true" > "$MW_LAYER.toml"
 
 
 # test that we can load the user function
-echo "require('$MW_LAYER/dist/userFnLoader').default()" | USER_FUNCTION_PACKAGE_NAME=$USER_FUNCTION_PACKAGE_NAME node
+echo "require('$MW_LAYER/dist/userFnLoader').default()" | SF_FUNCTION_PACKAGE_NAME=$SF_FUNCTION_PACKAGE_NAME node

--- a/bin/build
+++ b/bin/build
@@ -45,6 +45,10 @@ fi
 # Setup user function as a node module dependency in the middleware and allow
 # the user function to be required by name.
 SF_FUNCTION_PACKAGE_NAME=$(jq -r '.name' < /workspace/package.json)
+if [[ -z "${SF_FUNCTION_PACKAGE_NAME}" ]]; then
+  echo "Salesforce function package name not defined. Does the package.json have a 'name'?"
+  exit 1
+fi
 echo -n "$SF_FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/SF_FUNCTION_PACKAGE_NAME.override"
 ln -s /workspace "$MW_LAYER/node_modules/$SF_FUNCTION_PACKAGE_NAME"
 

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -19,6 +19,7 @@ import {
     X_FORWARDED_HOST,
     X_FORWARDED_PROTO
 } from './lib/constants';
+import loadUserFunction from './userFnLoader';
 
 const httpReceiver = new HTTPReceiver();
 
@@ -157,7 +158,7 @@ function parseCloudEvent(logger: Logger, headers: Map<string,string>, body: any)
     return httpReceiver.accept(headers, Object.assign({}, body));
 }
 
-const userFn = require(process.env["FUNCTION_PACKAGE_NAME"]);
+const userFn = loadUserFunction();
 
 export default async function systemFn(message: any): Promise<any> {
     // Remap riff headers to a standard JS object with lower-case keys

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -19,7 +19,6 @@ import {
     X_FORWARDED_HOST,
     X_FORWARDED_PROTO
 } from './lib/constants';
-import loadUserFunction from './userFnLoader';
 
 const httpReceiver = new HTTPReceiver();
 
@@ -158,7 +157,7 @@ function parseCloudEvent(logger: Logger, headers: Map<string,string>, body: any)
     return httpReceiver.accept(headers, Object.assign({}, body));
 }
 
-const userFn = loadUserFunction();
+const userFn = require(process.env["FUNCTION_PACKAGE_NAME"]);
 
 export default async function systemFn(message: any): Promise<any> {
     // Remap riff headers to a standard JS object with lower-case keys

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -158,7 +158,7 @@ function parseCloudEvent(logger: Logger, headers: Map<string,string>, body: any)
     return httpReceiver.accept(headers, Object.assign({}, body));
 }
 
-const userFn = loadUserFunction();
+const userFn = loadUserFunction(process.env["SF_FUNCTION_PACKAGE_NAME"]);
 
 export default async function systemFn(message: any): Promise<any> {
     // Remap riff headers to a standard JS object with lower-case keys

--- a/middleware/userFnLoader.ts
+++ b/middleware/userFnLoader.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export default function loadUserFunction(): any {
-  const packageName = process.env["USER_FUNCTION_PACKAGE_NAME"];
+  const packageName = process.env["SF_FUNCTION_PACKAGE_NAME"];
   if (!packageName) {
     console.dir(process.env);
-    throw `Could not locate function module, $USER_FUNCTION_PACKAGE_NAME not defined.`;
+    throw `Could not locate function module, $SF_FUNCTION_PACKAGE_NAME not defined.`;
   }
   let mod;
   try {

--- a/middleware/userFnLoader.ts
+++ b/middleware/userFnLoader.ts
@@ -1,21 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as path from "path";
 
 export default function loadUserFunction(): any {
-  const functionPath = process.env.USER_FUNCTION_URI || '/workspace';
-  const pjsonPath = path.join(functionPath, 'package.json');
-  let main = '';
-  try {
-    main = require(pjsonPath).main;
-  } catch (e) {
-    throw `Could not read package.json: ${e}`;
+  const packageName = process.env["USER_FUNCTION_PACKAGE_NAME"];
+  if (!packageName) {
+    console.dir(process.env);
+    throw `Could not locate function module, $USER_FUNCTION_PACKAGE_NAME not defined.`;
   }
-  const mainPath = path.join(functionPath, main);
   let mod;
   try {
-    mod = require(mainPath);
-  } catch (e) {
-    throw `Could not locate user function: ${e}`;
+    mod = require(packageName);
+  } catch (err) {
+    throw `Could not locate function module: ${err}`;
   }
   if (mod.__esModule && typeof mod.default === 'function') {
     return mod.default;

--- a/middleware/userFnLoader.ts
+++ b/middleware/userFnLoader.ts
@@ -1,16 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export default function loadUserFunction(): any {
-  const packageName = process.env["SF_FUNCTION_PACKAGE_NAME"];
+export default function loadUserFunction(packageName: string): any {
   if (!packageName) {
-    console.dir(process.env);
-    throw `Could not locate function module, $SF_FUNCTION_PACKAGE_NAME not defined.`;
+    throw `Could not locate salesforce function module: package name not defined.`;
   }
   let mod;
   try {
     mod = require(packageName);
   } catch (err) {
-    throw `Could not locate function module: ${err}`;
+    throw `Could not locate salesforce function module: ${err}`;
   }
   if (mod.__esModule && typeof mod.default === 'function') {
     return mod.default;


### PR DESCRIPTION
Symlinking the user function as a middleware dependency allows us to use node's native module resolution system and support multiple installations of the same package. This will prevent functions from crashing when using a different version of the `@salesforce/salesforce-sdk` than what is used in this middleware. 

Note that this does not enforce compatibility between of the customer's and middleware's SDK version. This allows each to run it's own version. This could still be confusing, and we should (at a minimum) add warnings when we see mismatches in another PR.

An example directory structure after this change looks like this:
```
heroku@0b9b708b75cb:/workspace$ cat /layers/salesforce_nodejs-fn/middleware/node_modules/\@salesforce/salesforce-sdk/package.json | grep "version"
  "version": "1.3.1"
heroku@0b9b708b75cb:/workspace$ cat /layers/salesforce_nodejs-fn/middleware/node_modules/boxybrown-function/node_modules/\@salesforce/salesforce-sdk/package.json | grep "version"
  "version": "1.1.2",
```

This is a fix for this [GUS Item](https://gus.lightning.force.com/a07B0000008NmGzIAK).