### PR TITLE
Check and warn when user and middleware SDK versions are incompatible

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -57,6 +57,15 @@ echo "Installing $SF_FUNCTION_PACKAGE_NAME"
 echo -n "$SF_FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/SF_FUNCTION_PACKAGE_NAME.override"
 ln -s /workspace "$MW_LAYER/node_modules/$SF_FUNCTION_PACKAGE_NAME"
 
+# Check that user's salesforce-sdk version is compatible with the middleware's.
+if [[ -f "/workspace/package-lock.json" ]]; then
+  SF_FUNCTION_SDK_VERSION=$(jq -r '.dependencies["@salesforce/salesforce-sdk"].version // empty' < /workspace/package-lock.json)
+fi
+if [[ -n "${SF_FUNCTION_SDK_VERSION}" ]]; then
+  SF_MIDDLEWARE_SDK_RANGE=$(jq -r '.dependencies["@salesforce/salesforce-sdk"] // empty' < "$MW_LAYER/package.json")
+  echo "require('$MW_LAYER/dist/versionChecker').default('@salesforce/salesforce-sdk', '$SF_FUNCTION_SDK_VERSION', '$SF_MIDDLEWARE_SDK_RANGE')" | node
+fi
+
 mkdir -p "$MW_LAYER/env.launch"
 if [[ ! -z "${DEBUG_PORT}" ]]; then
   echo -n "--inspect=0.0.0.0:${DEBUG_PORT}" > "$MW_LAYER/env.launch/NODE_OPTIONS.override"

--- a/middleware/test/unit/VersionCheckerTests.ts
+++ b/middleware/test/unit/VersionCheckerTests.ts
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import 'mocha';
+
+describe("versionChecker", function() {
+  describe("versionsComatible", function() {
+    const versionsCompatible = require('../../versionChecker').default;
+    it('returns false when incompatbile', function() {
+      expect(versionsCompatible("module", "0.1.1", "> 5.0")).to.be.false;
+    });
+    it('returns true when compatbile', function() {
+      expect(versionsCompatible("fakemodule", "1.2.5", "~ 1.2.0")).to.be.true;
+    });
+  });
+});

--- a/middleware/versionChecker.ts
+++ b/middleware/versionChecker.ts
@@ -1,0 +1,9 @@
+import * as semver from 'semver';
+
+export default function versionsCompatible(moduleName: string, requestedVersion: string, requiredVersionRange: string): boolean {
+  if (!semver.satisfies(requestedVersion, requiredVersionRange)) {
+    console.warn(`WARNING: The salesforce function's installed ${moduleName} version(${requestedVersion}) is not compatible with the version required by the function engine. Please update ${moduleName} to ${requiredVersionRange}`);
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
In #50, we're allowing broad incompatiblities between the function and middleware `@salesforce/salesforce-sdk` versions. This is likely to cause confusion and potentially errors as a result. We'd like to at least warn customers when we can detect an incompatibility. This adds that messaging.

Like #50, the work is linked to [this GUS item](https://gus.lightning.force.com/a07B0000008NmGzIAK).