### PR TITLE
Async fix, CloudEvents 3.1.0, prep for 1.9.0 release

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.8.0"
+version = "1.9.0"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -840,20 +840,31 @@
         }
       }
     },
-    "cloudevents-sdk": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/cloudevents-sdk/-/cloudevents-sdk-2.0.2.tgz",
-      "integrity": "sha512-sXTYWUFbUYg75b+71MH7AhHsEC4iCdlxf4W9flveRbih6xSDOuLryWbCuBZpeO1iLrt5uT1gD1flB38RhVSVBQ==",
+    "cloudevents": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-3.1.0.tgz",
+      "integrity": "sha512-98t6+Qs/r2PiYflNFztUcPSDfaaRU8KKMzaMR4dn9MPpijZj3A1W+L307t00D6xRzXdkDDiMcB2THS3dCp+kcw==",
       "requires": {
-        "ajv": "~6.12.0",
+        "ajv": "~6.12.3",
         "axios": "~0.19.2",
-        "uuid": "~8.0.0"
+        "uuid": "~8.2.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "uuid": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
         }
       }
     },

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@projectriff/message": "^1.0.0",
     "@salesforce/salesforce-sdk": "^1.3.1",
-    "cloudevents-sdk": "^2.0.2"
+    "cloudevents": "^3.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",

--- a/middleware/test/unit/FunctionTestUtils.ts
+++ b/middleware/test/unit/FunctionTestUtils.ts
@@ -5,7 +5,7 @@ import {
     FN_INVOCATION
 } from '../../lib/constants';
 import { FunctionInvocationRequest } from '../../lib/FunctionInvocationRequest';
-import { CloudEvent } from 'cloudevents-sdk/lib/cloudevent';
+import { CloudEvent, Headers as CEHeaders } from 'cloudevents';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const portHeaderPart = 6666;
@@ -88,15 +88,15 @@ export const generateCloudevent = (data: any, async = false, specVersion = '0.3'
     return ce;
 };
 
-export const generateRawMiddleWareRequest = (data: any, async = false): [CloudEvent, ReadonlyMap<string,string>] => {
+export const generateRawMiddleWareRequest = (data: any, async = false): [CloudEvent, CEHeaders] => {
     const cloudEvent: CloudEvent = generateCloudevent(data, async);
-    const rawheaders = {
+    const headers = {
         'authorization' : 'C2C eyJ2ZXIiOiIxLjAiLCJraWQiOiJDT1J',
         'content-type' : 'application/json',
         X_FORWARDED_HOST : hostHeader, // test case insensitive lookup
         X_FORWARDED_PROTO: 'http'
     };
-    return [cloudEvent, new Map(Object.entries(rawheaders))];
+    return [cloudEvent, headers];
 };
 
 export class FakeFunction {


### PR DESCRIPTION
* Fix for async requests passing through original content-length header (remove and let REST client set new one)
* Upgrade to CloudEvents 3.1.0 SDK and refactor to new API
* Prep for 1.9.0 release