### PR TITLE
Fix middleware error "Cannot use 'in' operator to search for 'data' in <string>"

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.9.0"
+version = "1.9.1"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",


### PR DESCRIPTION
The latest `evergreen-build 0.17.0` plugin will send properly-escaped JSON `string` values on an `sfdx evergreen:function:invoke` call when the payload is not a parseable JSON object.  Unfortunately, the middleware made some prior assumptions about the payload being `object`-only, so was checking for keys without checking if it was an object first.  And, because the riff middleware strips the quotes from the JSON string body (if a string is posted), we need to add those back in before Cloudevents parsing occurs.

== Verification

To verify, create a `payload.txt` file that contains non-JSON content but a couple special json chars that require escaping:
```text
 [This
is. "something" }
 payload
```

In one window, start your function with current (1.9.0) middleware:
```sh
$ sfdx evergreen:function:start --clear-cache
...
2020-08-26T15:53:38 Ready to process signals
```

In other window, invoke the function with above payload:
```sh
sfdx evergreen:function:invoke -p @payload.txt http://127.0.0.1:8080/
```

Expected result: successful function invocation
Current (1.9.0) result: Error: Request failed with status code 500.  Function logs show `Cannot use 'in' operator...`.

Testing this prior to merge -- check out this branch and:
```sh
$ make image
```

In your function:start window, do a Ctrl-C to kill it, then start with this PR image:
```
$ sfdx evergreen:function:start --verbose --builder=nodejs-sf-fx-buildpacks:latest --no-pull --clear-cache
```

In your function:invoke window, re-invoke:
```
$ sfdx evergreen:function:invoke -p @payload.txt http://127.0.0.1:8080/
# And get same result with --structured
$ sfdx evergreen:function:invoke -p @payload.txt http://127.0.0.1:8080/ --structured
```

PR branch result: POST...200 OK
