### PR TITLE
bugfix(middleware): header check for async fulfill requests needs to be lower-case

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.9.1"
+version = "1.9.2"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -206,7 +206,7 @@ export default async function systemFn(message: any): Promise<any> {
         // If initial async request, invoke function again and release request
         isAsync = isAsyncRequest(cloudEvent.type);
         if (isAsync) {
-            if (!headers[ASYNC_FULFILL_HEADER]) {
+            if (!headers[ASYNC_FULFILL_HEADER.toLowerCase()]) {
                 requestLogger.info('Received initial async request');
                 await invokeAsyncFn(requestLogger, cloudEvent, headers);
                 // Function invoked on forwarded request; release initial client request

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",


### PR DESCRIPTION
* headers are lower cased at start of `systemFn`
* header prevents infinite loop, so check for header also needs to be lower cased
* Prep for 1.9.2 release
