### PR TITLE
Require a function.toml to pass detection

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-if [ -f package.json ]; then
-  echo "detected package.json"
+if [ -f package.json ] && [ -f function.toml ]; then
+  echo "detected Salesforce Function"
 
 cat << EOF > "$2"
 [[requires]]


### PR DESCRIPTION
Now that `function.toml` is required to use the CLI with functions, and that `function.toml` is included in all new functions, we can update `detect` to match. This means we can more authoritatively detect the difference between a Node Salesforce Function and a more generic node app, and even have the nodejs and sf-fx buildpacks in the same builder.

[GUS Item](https://gus.lightning.force.com/a07B0000008UsrfIAC)

