### PR TITLE
Prevent module errors on successive builds in the same container

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -8,6 +8,15 @@ echo "LAYERS_DIR: " $LAYERS_DIR
 MW_LAYER="$LAYERS_DIR/middleware"
 echo "MW_LAYER: " $MW_LAYER
 
+# Get the package name of the user function, to allow it to be required by name
+SF_FUNCTION_PACKAGE_NAME=$(jq -r '.name // empty' < /workspace/package.json)
+if [[ -z "${SF_FUNCTION_PACKAGE_NAME}" ]]; then
+  echo "Salesforce function package name not defined. Make sure there is a 'name' in package.json."
+  exit 1
+fi
+# Remove the user function package symlink if present from previous build
+rm -f "${MW_LAYER}/node_modules/${SF_FUNCTION_PACKAGE_NAME}"
+
 # Setup caching layer for middleware node_modules
 NODE_MODULES_DIR="${LAYERS_DIR}/node_modules" # the actual layer where the caching values are saved to
 touch "${NODE_MODULES_DIR}.toml"              # the layer toml file that tells lifecycle to enable cache
@@ -25,7 +34,6 @@ cached_lock_checksum=$(yj -t < "${NODE_MODULES_DIR}.toml" | jq -r ".metadata.pac
 
 if [[ "$local_lock_checksum" == "$cached_lock_checksum" ]] ; then
     echo "using previous node_modules and dist artifacts from cache"
-    rm "${MW_LAYER}/node_modules/*"
     cp -r "${NODE_MODULES_DIR}/." "${MW_LAYER}/node_modules"
 else
 
@@ -43,13 +51,7 @@ else
     cp -r "${MW_LAYER}/node_modules/." "${NODE_MODULES_DIR}"
 fi
 
-# Setup user function as a node module dependency in the middleware and allow
-# the user function to be required by name.
-SF_FUNCTION_PACKAGE_NAME=$(jq -r '.name // empty' < /workspace/package.json)
-if [[ -z "${SF_FUNCTION_PACKAGE_NAME}" ]]; then
-  echo "Salesforce function package name not defined. Make sure there is a 'name' in package.json."
-  exit 1
-fi
+# Install the user function as a middleware dependency, so it can be required
 if [[ -d "$MW_LAYER/node_modules/$SF_FUNCTION_PACKAGE_NAME" ]]; then
   echo "Salesforce function package name($SF_FUNCTION_PACKAGE_NAME) conflicts with existing module. Change the 'name' in package.json."
   exit 1

--- a/bin/build
+++ b/bin/build
@@ -25,6 +25,7 @@ cached_lock_checksum=$(yj -t < "${NODE_MODULES_DIR}.toml" | jq -r ".metadata.pac
 
 if [[ "$local_lock_checksum" == "$cached_lock_checksum" ]] ; then
     echo "using previous node_modules and dist artifacts from cache"
+    rm "${MW_LAYER}/node_modules/*"
     cp -r "${NODE_MODULES_DIR}/." "${MW_LAYER}/node_modules"
 else
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.9.2"
+version = "1.9.3"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",


### PR DESCRIPTION
Users may see errors like the following when triggering rebuilds during in a `sfdx evergreen:function:start` session:

```
2020-09-02T09:41:38 Salesforce function package name(my-neat-function) conflicts with existing module. Change the 'name' in package.json.
```

This happens because we create the symlink in the first build, and the successive build still has the symlink, so we think it's a user-installed package. This clears the symlink if it exists at the beginning of the build to avoid this problem.
