### PR TITLE
Error handling updates; remove async behavior

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,13 +28,13 @@
           "-u",
           "tdd",
           "--timeout",
-          "9999",
+          "99999",
           "--colors",
           "-r",
           "ts-node/register",
           "${file}"
       ],
-      "env": {"USER_FUNCTION_URI":"../middleware/test/fixtures/functions/mock"},
+      "env": {"SF_FUNCTION_PACKAGE_NAME":"../middleware/test/fixtures/functions/mock"},
       "cwd": "${fileDirname}",
       "internalConsoleOptions": "openOnSessionStart"
     },

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.9.4"
+version = "1.9.5"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -10,7 +10,7 @@ import { Context, InvocationEvent } from '@salesforce/salesforce-sdk';
 
 const FUNCTION_ERROR_CODE = '500';
 const INTERNAL_SERVER_ERROR_CODE = '503';
-const CURRENT_FILENAME: string = __filename;
+export const CURRENT_FILENAME: string = __filename;
 
 export class ExtraInfo {
     constructor(

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -12,7 +12,7 @@ const FUNCTION_ERROR_CODE = '500';
 const INTERNAL_SERVER_ERROR_CODE = '503';
 const CURRENT_FILENAME: string = __filename;
 
-class ExtraInfo {
+export class ExtraInfo {
     constructor(
         public readonly requestId: string,  // incoming x-request-id
         public readonly source: string,     // incoming ce.source
@@ -43,7 +43,7 @@ class ExtraInfo {
         }
 
         // Return stack to last desired frame
-        return stackParts.slice(0, foundLastIdx).join('\n');
+        return stackParts.slice(0, foundLastIdx + 1).join('\n');
     }
 }
 class MiddlewareError extends Error {

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -19,11 +19,11 @@ export class ExtraInfo {
         public readonly execTimeMs: number, // function invocation time
         public stack = ''          // error stack, if applicable
         ) {
-        this.stack = encodeURI(this.trim(stack));
+        this.setStack(stack);
     }
 
     public setStack(stack: string): void {
-        this.stack = encodeURI(this.trim(stack));
+        this.stack = this.trim(stack);
     }
 
     private trim(stack = ''): string {
@@ -91,7 +91,7 @@ function buildResponse(code: string, response: any, extraInfo: ExtraInfo): any {
     return Message.builder()
         .addHeader('content-type', 'application/json')
         .addHeader('x-http-status', code)
-        .addHeader('x-extra-info', JSON.stringify(extraInfo))
+        .addHeader('x-extra-info', encodeURI(JSON.stringify(extraInfo)))
         .payload(typeof response === 'string' ? response : JSON.stringify(response))
         .build();
 }

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -26,7 +26,7 @@ export class ExtraInfo {
         this.stack = encodeURI(this.trim(stack));
     }
 
-    private trim(stack: string): string {
+    private trim(stack = ''): string {
         if (stack.length === 0) {
             return stack
         }

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -3,23 +3,28 @@
 import {Logger, LoggerFormat, LoggerLevel} from '@salesforce/core/lib/logger';
 import {CloudEvent,Headers as CEHeaders,Receiver} from 'cloudevents';
 const {Message} = require('@projectriff/message');
-const http = require('http');
-const https = require('https');
 import {applySfFnMiddleware} from './lib/sfMiddleware';
-import {
-    FunctionInvocationRequest,
-    saveFnInvocation,
-    saveFnInvocationError
-} from './lib/FunctionInvocationRequest';
-import {
-    ASYNC_CE_TYPE,
-    ASYNC_FULFILL_HEADER,
-    FN_INVOCATION,
-    X_FORWARDED_HOST,
-    X_FORWARDED_PROTO
-} from './lib/constants';
 import loadUserFunction from './userFnLoader';
+import { Context, InvocationEvent } from '@salesforce/salesforce-sdk';
 
+const FUNCTION_ERROR_CODE = '500';
+const INTERNAL_SERVER_ERROR_CODE = '503';
+
+class MiddlewareError extends Error {
+
+    public readonly stack: string;
+
+    constructor(public readonly err: Error, public readonly code: string) {
+        super(err.message);
+        Object.setPrototypeOf(this, new.target.prototype);
+        // TODO: Trim stack from this file up
+        this.stack = err.stack
+    }
+
+    public toString(): string {
+        return this.err.toString();
+    }
+}
 
 function createLogger(requestID?: string): Logger {
     const logger = new Logger({
@@ -37,75 +42,21 @@ function createLogger(requestID?: string): Logger {
     return logger;
 }
 
-function errorMessage(error: Error): any {
+function buildErrorResponse(err: Error): any {
+    // any error in user-function-space should be considered a 500 toerhwi
+    // ensure we send down application/json in this case
+    return buildResponse(err instanceof MiddlewareError ? err.code : INTERNAL_SERVER_ERROR_CODE, err.message, err.stack);
+}
+
+function buildResponse(code: string, response: any, extraInfo?: string): any {
     // any error in user-function-space should be considered a 500
     // ensure we send down application/json in this case
     return Message.builder()
         .addHeader('content-type', 'application/json')
-        .addHeader('x-http-status', '500')
-        .payload({
-            error: error.toString(),
-        })
+        .addHeader('x-http-status', code)
+        .addHeader('x-extra-info', extraInfo || '')
+        .payload(typeof response === 'string' ? response : JSON.stringify(response))
         .build();
-}
-
-function isAsyncRequest(type: string): boolean {
-    return type && type.startsWith(ASYNC_CE_TYPE);
-}
-
-// Invoke given function again to fulfill async request; response is not handled
-async function invokeAsyncFn(logger: Logger, cloudEvent: CloudEvent, headers: any): Promise<void> {
-    // host header is required.  Headers are already convered to lower-case in systemFn.
-    const hostUrl = headers[X_FORWARDED_HOST];
-    if (!hostUrl) {
-        throw new Error('Unable to determine host for async invocation');
-    }
-
-    const hostParts = hostUrl.split(':');
-    let isHttps = true;
-    if (headers[X_FORWARDED_PROTO]) {
-        isHttps = headers[X_FORWARDED_PROTO].toLowerCase() === 'https';
-    }
-
-    // length changes after body content updates
-    delete headers['content-length'];
-
-    const options = {
-        hostname: hostParts[0],
-        port: hostParts[1] ? parseInt(hostParts[1]) : (isHttps ? 443 : 80),
-        method: 'POST',
-        path: '/',
-        headers: {...headers, [ASYNC_FULFILL_HEADER]: true}
-    };
-
-    // Invoke function and ignore response
-    const lib = isHttps ? https : http;
-    return new Promise((resolve, reject) => {
-        const expectedErrCode = 'EXPECTED_ECONNRESET';
-        const req = lib.request(options);
-        req.on('error', async (err) => {
-            if (req.destroyed && err['code'] === expectedErrCode) {
-                // Expected to terminate response
-                resolve();
-            } else {
-                // Return error for async request client
-                reject(err);
-            }
-        });
-
-        // Forward original request
-        req.write(cloudEvent.toString());
-
-        // Flush and finishes sending the request
-        req.end(() => {
-            logger.info('Forwarded async request');
-
-            // Forget response and destroy the socket
-            const expectedErr = new Error();
-            expectedErr['code'] = expectedErrCode;
-            req.destroy(expectedErr);
-        });
-    });
 }
 
 /**
@@ -144,7 +95,7 @@ function parseCloudEvent(logger: Logger, headers: CEHeaders, body: any): CloudEv
 
     // Core API 48.0 and below send an 0.2-format CloudEvent that needs to be reformatted
     if (bodyIsObj &&
-            'specVersion' in body && 
+            'specVersion' in body &&
             '0.2' === body['specVersion']) {
         _mv(body, 'specVersion', 'specversion', '0.3');
         _mv(body, 'contentType', 'datacontenttype');
@@ -153,8 +104,8 @@ function parseCloudEvent(logger: Logger, headers: CEHeaders, body: any): CloudEv
         logger.info('Translated cloudevent 0.2 to 0.3 format');
 
         // Initial deployment of Core API 50.0 send the wrong content-type, need to adjust
-    } else if (ctype.includes('application/json') && 
-            bodyIsObj && 
+    } else if (ctype.includes('application/json') &&
+            bodyIsObj &&
             'specversion' in body) {
         headers['content-type'] = 'application/cloudevents+json';
         logger.info('Forced content-type to: application/cloudevents+json');
@@ -162,7 +113,7 @@ function parseCloudEvent(logger: Logger, headers: CEHeaders, body: any): CloudEv
 
     // make a clone of the body if object - cloudevents sdk deletes keys as it parses.
     // otherwise Receiver will do a JSON parse so need to re-stringify any string body
-    const bodyShallowCopy = bodyIsObj ? Object.assign({}, body) : 
+    const bodyShallowCopy = bodyIsObj ? Object.assign({}, body) :
             JSON.stringify(body);
     return Receiver.accept(headers, bodyShallowCopy);
 }
@@ -177,7 +128,7 @@ export default async function systemFn(message: any): Promise<any> {
     let bodyPayload: any = message['payload'];
     if (typeof bodyPayload === 'object' &&
             'data' in bodyPayload &&
-            'ce-id' in headers && 
+            'ce-id' in headers &&
             headers['ce-specversion'] === '0.3') {
         bodyPayload = bodyPayload['data'];
     }
@@ -185,7 +136,7 @@ export default async function systemFn(message: any): Promise<any> {
     // Initialize logger with request ID
     const requestId = headers['ce-id'] || headers['x-request-id'] || bodyPayload['id'];
     const requestLogger = createLogger(requestId);
-  
+
     // Parse input according to Cloudevents 0.2, 0.3 or 1.0 specification
     let cloudEvent: CloudEvent;
     try {
@@ -194,60 +145,34 @@ export default async function systemFn(message: any): Promise<any> {
         // Only log toplevel input keys since values can contain credentials or PII
         requestLogger.fatal(`Failed to parse CloudEvent content-type=${headers['content-type']} body keys=${Object.keys(bodyPayload)}`);
         requestLogger.fatal(parseErr);
-        return Message.builder()
-            .addHeader('content-type', 'application/json')
-            .addHeader('x-http-status', '400')
-            .payload(JSON.stringify({error: parseErr.toString()}))
-            .build();
+        return buildResponse('400', parseErr.message, parseErr.stack);
     }
 
-    let isAsync = false;
     try {
-        // If initial async request, invoke function again and release request
-        isAsync = isAsyncRequest(cloudEvent.type);
-        if (isAsync) {
-            if (!headers[ASYNC_FULFILL_HEADER.toLowerCase()]) {
-                requestLogger.info('Received initial async request');
-                await invokeAsyncFn(requestLogger, cloudEvent, headers);
-                // Function invoked on forwarded request; release initial client request
-                return Message.builder()
-                    .addHeader('content-type', 'application/json')
-                    .addHeader('x-http-status', '202')
-                    .payload('')
-                    .build();
-            } else {
-                requestLogger.info('Fulfilling async request');
-            }
-        }
-
         let result: any;
-        let fnInvocation: FunctionInvocationRequest;
+        let event: InvocationEvent;
+        let context: Context;
+        let logger: Logger;
         try {
             // Create function param objects from request
-            const [event, context, logger] = applySfFnMiddleware(cloudEvent, headers, requestLogger);
-            fnInvocation = context[FN_INVOCATION];
-
-            // Invoke requested function
-            result = await userFn(...[event, context, logger]);
-
-            // If async, save result to associated function invocation request
-            if (isAsync) {
-                await saveFnInvocation(requestLogger, fnInvocation, result);
-            }
-
-            // Currently, riff doesn't support undefined or null return values
-            return result || '';
-        } catch (invokeErr) {
-            // If async, save error to associated function invocation request
-            if (isAsync) {
-                await saveFnInvocationError(requestLogger, fnInvocation, invokeErr.message);
-            }
-
-            throw invokeErr;
+            [event, context, logger] = applySfFnMiddleware(cloudEvent, headers, requestLogger);
+        } catch (apiSetupError) {
+            throw new MiddlewareError(apiSetupError, INTERNAL_SERVER_ERROR_CODE);
         }
+
+        // Invoke requested function
+        try {
+            result = await userFn(...[event, context, logger]);
+        } catch (invokeErr) {
+            throw new MiddlewareError(invokeErr, FUNCTION_ERROR_CODE);
+        }
+
+        // Currently, riff doesn't support undefined or null return values
+        return result || '';
+
     } catch (error) {
         requestLogger.error(error.toString());
-        return errorMessage(error);
+        return buildErrorResponse(error);
     }
 }
 

--- a/middleware/lib/FunctionInvocationRequest.ts
+++ b/middleware/lib/FunctionInvocationRequest.ts
@@ -16,7 +16,7 @@ export enum FunctionInvocationRequestStatusEnum {
 // Does not throw
 export async function saveFnInvocation(logger: Logger,
                                        fnInvocation: FunctionInvocationRequest,
-                                       response: any,
+                                       response: FunctionInvocationResponse,
                                        status: FunctionInvocationRequestStatusEnum = FunctionInvocationRequestStatusEnum.Success): Promise<void> {
     if (!fnInvocation) {
         return;
@@ -31,8 +31,14 @@ export async function saveFnInvocation(logger: Logger,
     }
 }
 
-export async function saveFnInvocationError(logger: Logger, fnInvocation: FunctionInvocationRequest, response: any): Promise<void> {
+export async function saveFnInvocationError(logger: Logger, fnInvocation: FunctionInvocationRequest, response: FunctionInvocationResponse): Promise<void> {
     return await saveFnInvocation(logger, fnInvocation, response, FunctionInvocationRequestStatusEnum.Error);
+}
+
+export interface FunctionInvocationResponse {
+    code: string;
+    response: any;
+    extraInfo?: any;
 }
 
 // TODO: Remove when FunctionInvocationRequest is deprecated.

--- a/middleware/lib/constants.ts
+++ b/middleware/lib/constants.ts
@@ -1,5 +1,1 @@
-export const ASYNC_CE_TYPE = 'com.salesforce.function.invoke.async';
-export const ASYNC_FULFILL_HEADER = 'X-Async-Fulfill-Request';
 export const FN_INVOCATION = 'fnInvocation';
-export const X_FORWARDED_HOST = 'x-forwarded-host';
-export const X_FORWARDED_PROTO = 'x-forwarded-proto';

--- a/middleware/lib/sfMiddleware.ts
+++ b/middleware/lib/sfMiddleware.ts
@@ -107,18 +107,16 @@ function createOrg(logger: Logger, reqContext: any, accessToken?: string): Org {
     let dataApi: DataApi | undefined;
     let unitOfWork: UnitOfWork | undefined;
     let unitOfWorkGraph: UnitOfWorkGraph | undefined;
-    if (accessToken) {
-        const config: ConnectionConfig = new ConnectionConfig(
-            accessToken,
-            apiVersion,
-            userContext.salesforceBaseUrl
-        );
-        unitOfWork = new UnitOfWork(config, logger);
-        if (apiVersion >= APIVersion.V50) {
-            unitOfWorkGraph = new UnitOfWorkGraph(config, logger);
-        }
-        dataApi = new DataApi(config, logger);
+    const config: ConnectionConfig = new ConnectionConfig(
+        accessToken,
+        apiVersion,
+        userContext.salesforceBaseUrl
+    );
+    unitOfWork = new UnitOfWork(config, logger);
+    if (apiVersion >= APIVersion.V50) {
+        unitOfWorkGraph = new UnitOfWorkGraph(config, logger);
     }
+    dataApi = new DataApi(config, logger);
 
     return new Org(
         apiVersion,
@@ -154,7 +152,7 @@ function createContext(id: string, logger: Logger, secrets: Secrets, reqContext?
 
     // If functionInvocationId is provided, create and set FunctionInvocationRequest object
     let fnInvocation: FunctionInvocationRequest;
-    if (accessToken && functionInvocationId) {
+    if (functionInvocationId) {
         fnInvocation = new FunctionInvocationRequest(functionInvocationId, logger, org.data);
         context[FN_INVOCATION] = fnInvocation;
     }

--- a/middleware/lib/sfMiddleware.ts
+++ b/middleware/lib/sfMiddleware.ts
@@ -103,20 +103,18 @@ function createOrg(logger: Logger, reqContext: any, accessToken?: string): Org {
 
     const user = createUser(userContext);
 
-    // If accessToken was provided, setup APIs.
-    let dataApi: DataApi | undefined;
-    let unitOfWork: UnitOfWork | undefined;
+    logger.info(`accessToken${accessToken ? ' ' : ' NOT '}provided.`);
     let unitOfWorkGraph: UnitOfWorkGraph | undefined;
     const config: ConnectionConfig = new ConnectionConfig(
         accessToken,
         apiVersion,
         userContext.salesforceBaseUrl
     );
-    unitOfWork = new UnitOfWork(config, logger);
+    const unitOfWork = new UnitOfWork(config, logger);
     if (apiVersion >= APIVersion.V50) {
         unitOfWorkGraph = new UnitOfWorkGraph(config, logger);
     }
-    dataApi = new DataApi(config, logger);
+    const dataApi = new DataApi(config, logger);
 
     return new Org(
         apiVersion,

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",
@@ -11,7 +11,7 @@
     "build": "node_modules/typescript/bin/tsc",
     "lint": "eslint './*.ts' 'test/**/*.ts' --ext .ts",
     "start": "node dist/index",
-    "test": "cross-env USER_FUNCTION_URI=../middleware/test/fixtures/functions/mock nyc --extension .ts mocha --forbid-only --timeout 99999 -r ts-node/register 'test/unit/**/*.ts'",
+    "test": "cross-env SF_FUNCTION_PACKAGE_NAME=../middleware/test/fixtures/functions/mock nyc --extension .ts mocha --forbid-only --timeout 99999 -r ts-node/register 'test/unit/**/*.ts'",
     "test-debug": "nyc --extension .ts mocha --inspect-brk=9229 --forbid-only -r ts-node/register 'test/unit/**/*.ts'",
     "watch-node": "nodemon dist/index.js",
     "watch": "tsc -w"

--- a/middleware/test/fixtures/functions/mock/index.js
+++ b/middleware/test/fixtures/functions/mock/index.js
@@ -10,9 +10,12 @@
  * @param logger:  logging handler used to capture application logs and traces specific
  *                 to a given execution of a function.
  */
-module.exports = function (event, context, logger) {
+module.exports = async function (event, context, logger) {
     if (event.data && event.data.shouldThrowError) {
         throw new Error('FakeError');
     }
+
+    await new Promise(r => setTimeout(r, 1000));
+
     return {'success': true};
 }

--- a/middleware/test/fixtures/functions/mock/index.js
+++ b/middleware/test/fixtures/functions/mock/index.js
@@ -15,7 +15,7 @@ module.exports = async function (event, context, logger) {
         throw new Error('FakeError');
     }
 
-    await new Promise(r => setTimeout(r, 1000));
+    await new Promise(r => setTimeout(r, 2000));
 
     return {'success': true};
 }

--- a/middleware/test/fixtures/functions/mock/index.js
+++ b/middleware/test/fixtures/functions/mock/index.js
@@ -11,11 +11,11 @@
  *                 to a given execution of a function.
  */
 module.exports = async function (event, context, logger) {
+    await new Promise(r => setTimeout(r, 2000));
+
     if (event.data && event.data.shouldThrowError) {
         throw new Error('FakeError');
     }
-
-    await new Promise(r => setTimeout(r, 2000));
 
     return {'success': true};
 }

--- a/middleware/test/unit/ContextTests.ts
+++ b/middleware/test/unit/ContextTests.ts
@@ -106,17 +106,14 @@ describe('Context Tests', () => {
         expect(context[FN_INVOCATION].id).to.equal(fnInvocationId);
 
         // Validate ConnectionConfig has expected values
-        // TODO: Prevent this, somehow.
         const connConfig: ConnectionConfig = context.org.data['connConfig'];
         expect(connConfig).to.exist;
-        // TODO: Prevent access to accessToken
         expect(connConfig.accessToken).to.equal(accessToken);
         expect(connConfig.apiVersion).to.equal(data.context.apiVersion);
         expect(connConfig.instanceUrl).to.equal(data.context.userContext.salesforceBaseUrl);
 
         // Ensure accessToken was not serialized
         const dataApiJSON = JSON.stringify(context.org.data);
-        expect(dataApiJSON).to.exist;
         expect(dataApiJSON).to.not.contain('accessToken');
 
         // Validate Connection has expected values
@@ -137,10 +134,11 @@ describe('Context Tests', () => {
         validateContext(data, context);
 
         // Requires accessToken
-        expect(context.org.data).to.not.exist;
-        expect(context.org.unitOfWork).to.not.exist;
-        expect(context.org.unitOfWorkGraph).to.not.exist;
-        expect(context[FN_INVOCATION]).to.not.exist;
+        expect(context.org.data).to.exist;
+        expect(JSON.stringify(context.org.data)).to.not.contain('accessToken');
+        expect(context.org.unitOfWork).to.exist;
+        expect(context.org.unitOfWorkGraph).to.exist;
+        expect(context[FN_INVOCATION]).to.exist;
     });
 
     it('validate API version override', () => {

--- a/middleware/test/unit/FunctionTestUtils.ts
+++ b/middleware/test/unit/FunctionTestUtils.ts
@@ -1,9 +1,6 @@
 import {Context} from '@salesforce/salesforce-sdk';
 import * as sinon from 'sinon';
-import {
-    ASYNC_CE_TYPE,
-    FN_INVOCATION
-} from '../../lib/constants';
+import {FN_INVOCATION} from '../../lib/constants';
 import {FunctionInvocationRequest} from '../../lib/FunctionInvocationRequest';
 import {CloudEvent, Headers as CEHeaders} from 'cloudevents';
 
@@ -64,25 +61,25 @@ export const encodeCeAttrib = (toEncode: any): string => {
     return Buffer.from(asJson).toString('base64');
 };
 
-export const generateCloudevent = (data: any, async = false, specVersion = '0.3'): CloudEvent => {
-    const ce = new CloudEvent({
-        specversion: specVersion,
+export const generateCloudevent = (data: any, async = false, specversion = '0.3'): CloudEvent => {
+    let ce = new CloudEvent({
+        specversion,
         id: '00Dxx0000006GY7-4SROyqmXwNJ3M40_wnZB1k',
         datacontenttype: 'application/json',
-        type: async ? ASYNC_CE_TYPE : 'com.salesforce.function.invoke',
+        type: 'com.salesforce.function.invoke',
         schemaurl: '',
         source: 'urn:event:from:salesforce/xx/224.0/00Dxx0000006GY7/InvokeFunctionController/9mdxx00000004ov',
         time: '2019-11-14T18:13:45.627813Z',
         data: {}
     });
-    if (specVersion === '0.3') {
+    if (specversion === '0.3') {
         ce.data = data;
     }
     else {
         // A 1.0+ spec CloudEvent will have ONLY the customer data in the data attribute.  Contexts are
         // base64-encoded-json extension attributes.
-        ce.addExtension('sfcontext', encodeCeAttrib(data.context));
-        ce.addExtension('sffncontext', encodeCeAttrib(data.sfContext));
+        ce = ce.cloneWith({'sfcontext': encodeCeAttrib(data.context)});
+        ce = ce.cloneWith({'sffncontext': encodeCeAttrib(data.sfContext)});
         ce.data = data.payload;
     }
     return ce;

--- a/middleware/test/unit/InvokeTests.ts
+++ b/middleware/test/unit/InvokeTests.ts
@@ -177,6 +177,7 @@ describe('Invoke Function Tests', () => {
     it('should parse stack', async () => {
         const extraInfo = new ExtraInfo('requestId', 'source', 1);
         const msg = 'Ooooops';
+
         extraInfo.setStack(`Error: ${msg}\n    at parseCloudEvent (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/index.ts:156:7)\n    at Object.systemFn [as default] (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/index.ts:183:22)\n    at Context.<anonymous> (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/test/unit/InvokeTests.ts:226:66)\n    at callFn (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runnable.js:372:21)\n    at Test.Runnable.run (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runnable.js:364:7)\n    at Runner.runTest (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:455:10)\n    at /home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:573:12\n    at next (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:369:14)`);
         expect(extraInfo.stack).to.not.be.empty;
         expect(extraInfo.stack).to.contain('%20'); // URI encoded - space
@@ -184,6 +185,9 @@ describe('Invoke Function Tests', () => {
         const stackParts = decodeURI(extraInfo.stack).split('\n');
         expect(stackParts).to.be.lengthOf(3);
         expect(stackParts[0]).to.be.contain(msg);
+
+        extraInfo.setStack(undefined);
+        expect(extraInfo.stack).to.be.lengthOf(0);
     });
 
     specVersions.forEach(function(specVersion : string) {

--- a/middleware/test/unit/InvokeTests.ts
+++ b/middleware/test/unit/InvokeTests.ts
@@ -180,9 +180,7 @@ describe('Invoke Function Tests', () => {
 
         extraInfo.setStack(`Error: ${msg}\n    at parseCloudEvent (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/index.ts:156:7)\n    at Object.systemFn [as default] (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/index.ts:183:22)\n    at Context.<anonymous> (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/test/unit/InvokeTests.ts:226:66)\n    at callFn (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runnable.js:372:21)\n    at Test.Runnable.run (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runnable.js:364:7)\n    at Runner.runTest (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:455:10)\n    at /home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:573:12\n    at next (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:369:14)`);
         expect(extraInfo.stack).to.not.be.empty;
-        expect(extraInfo.stack).to.contain('%20'); // URI encoded - space
-        expect(extraInfo.stack).to.contain('%0A'); // URI encoded - newline
-        const stackParts = decodeURI(extraInfo.stack).split('\n');
+        const stackParts = extraInfo.stack.split('\n');
         expect(stackParts).to.be.lengthOf(3);
         expect(stackParts[0]).to.be.contain(msg);
 
@@ -203,7 +201,10 @@ describe('Invoke Function Tests', () => {
             expect(fnResult.headers).to.be.not.null;
             expect(fnResult.headers.getValue('x-http-status')).to.be.equal('200');
             expect(fnResult.headers.getValue('x-extra-info')).to.be.not.null;
-            const extraInfo = JSON.parse(fnResult.headers.getValue('x-extra-info'));
+            const extraInfoEncoded = fnResult.headers.getValue('x-extra-info');
+            expect(extraInfoEncoded).to.contain('%22'); // URI encoded - quote
+            expect(extraInfoEncoded).to.contain('%7B'); // URI encoded - open paran
+            const extraInfo = JSON.parse(decodeURI(extraInfoEncoded));
             expect(extraInfo.requestId).to.not.be.empty;
             expect(extraInfo.source).to.not.be.empty;
             expect(extraInfo.execTimeMs).to.be.above(0);
@@ -222,13 +223,15 @@ describe('Invoke Function Tests', () => {
             expect(fnResult).to.be.not.null;
             expect(fnResult.headers.getValue('x-http-status')).to.be.equal('503');
             expect(fnResult.headers.getValue('x-extra-info')).to.be.not.null;
-            const extraInfo = JSON.parse(fnResult.headers.getValue('x-extra-info'));
+            const extraInfoEncoded = fnResult.headers.getValue('x-extra-info');
+            expect(extraInfoEncoded).to.contain('%20'); // URI encoded - space
+            expect(extraInfoEncoded).to.contain('%5Cn'); // URI encoded - newline
+            const extraInfo = JSON.parse(decodeURI(extraInfoEncoded));
             expect(extraInfo.requestId).to.not.be.empty;
             expect(extraInfo.source).to.not.be.empty;
             expect(extraInfo.execTimeMs).to.be.equal(-1);  // function was not invoked
             expect(extraInfo.stack).to.not.be.empty
             expect(extraInfo.stack).to.contain('applySfFnMiddleware');
-            expect(extraInfo.stack).to.contain('%20'); // URI encoded
             expect(decodeURI(extraInfo.stack)).to.contain('Error: Data field of the cloudEvent not provided in the request');
         });
 
@@ -242,7 +245,10 @@ describe('Invoke Function Tests', () => {
             expect(fnResult).to.be.not.null;
             expect(fnResult.headers.getValue('x-http-status')).to.be.equal('500');
             expect(fnResult.headers.getValue('x-extra-info')).to.be.not.null;
-            const extraInfo = JSON.parse(fnResult.headers.getValue('x-extra-info'));
+            const extraInfoEncoded = fnResult.headers.getValue('x-extra-info');
+            expect(extraInfoEncoded).to.contain('%20'); // URI encoded - space
+            expect(extraInfoEncoded).to.contain('%5Cn'); // URI encoded - newline
+            const extraInfo = JSON.parse(decodeURI(extraInfoEncoded));
             expect(extraInfo.requestId).to.not.be.empty;
             expect(extraInfo.source).to.not.be.empty;
             expect(extraInfo.execTimeMs).to.be.above(0);

--- a/middleware/test/unit/InvokeTests.ts
+++ b/middleware/test/unit/InvokeTests.ts
@@ -20,7 +20,7 @@ import {Message} from '@projectriff/message';
 const http = require('http');
 const https = require('https');
 const PassThrough = require('stream').PassThrough;
-import {ExtraInfo} from '../../index';
+import {CURRENT_FILENAME, ExtraInfo} from '../../index';
 import {applySfFnMiddleware} from '../../lib/sfMiddleware';
 import {FN_INVOCATION} from '../../lib/constants';
 import * as fnInvRequest from '../../lib/FunctionInvocationRequest';
@@ -178,7 +178,7 @@ describe('Invoke Function Tests', () => {
         const extraInfo = new ExtraInfo('requestId', 'source', 1);
         const msg = 'Ooooops';
 
-        extraInfo.setStack(`Error: ${msg}\n    at parseCloudEvent (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/index.ts:156:7)\n    at Object.systemFn [as default] (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/index.ts:183:22)\n    at Context.<anonymous> (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/test/unit/InvokeTests.ts:226:66)\n    at callFn (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runnable.js:372:21)\n    at Test.Runnable.run (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runnable.js:364:7)\n    at Runner.runTest (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:455:10)\n    at /home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:573:12\n    at next (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:369:14)`);
+        extraInfo.setStack(`Error: ${msg}\n    at parseCloudEvent (${CURRENT_FILENAME}:156:7)\n    at Object.systemFn [as default] (${CURRENT_FILENAME}:183:22)\n    at Context.<anonymous> (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/test/unit/InvokeTests.ts:226:66)\n    at callFn (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runnable.js:372:21)\n    at Test.Runnable.run (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runnable.js:364:7)\n    at Runner.runTest (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:455:10)\n    at /home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:573:12\n    at next (/home/cwall/git/nodejs-sf-fx-buildpack/middleware/node_modules/mocha/lib/runner.js:369:14)`);
         expect(extraInfo.stack).to.not.be.empty;
         const stackParts = extraInfo.stack.split('\n');
         expect(stackParts).to.be.lengthOf(3);


### PR DESCRIPTION
- Error handling:
  - Internal errors return `503`
  - Function errors return `500`
  - Return `x-extra-info` header, URI encoded, as (stack trimmed to last `/middleware/index` frame):
```
ExtraInfo {
    requestId: string; // incoming request id
    source: string; // incoming ce.source
    execTimeMs: number; // function invocation time
    stack?: string; // error stack, if applicable
}
```
- Remove async behavior.
- Initialize APIs (`org.data`, `UnitofWork`) even w/o `accessToken`.
- Fix tests