### PR TITLE
Support an HTTP health check from the sidecar/proxy

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "1.9.6"
+version = "1.9.7"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/index.ts
+++ b/middleware/index.ts
@@ -171,8 +171,15 @@ export default async function systemFn(message: any): Promise<any> {
         bodyPayload = bodyPayload['data'];
     }
 
-    // Initialize logger with request ID
+    // Determine request ID
     const requestId = headers['ce-id'] || headers['x-request-id'] || bodyPayload['id'];
+
+    // Handle health check calls identified by x-health-check request header
+    if ('x-health-check' in headers && headers['x-health-check'] === "true") {
+        return buildResponse(SUCCESS_CODE, "OK", new ExtraInfo(requestId, "x-health-check", 1, SUCCESS_CODE))
+    }
+
+    // Initialize logger with request ID
     const requestLogger = createLogger(requestId);
 
     let execTimeMs = -1;

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.9.5",
+  "version": "1.9.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",


### PR DESCRIPTION
Part 1 of 2 for [W-8111231](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07B0000008fm5kIAA)
- [x] Check for presense of HTTP Header `x-health-check: true`
- [x] If found, shortcut remainder of request processing and output a simple 200 `"OK"` response

Since RIFF Invoker's HTTP Streaming adapter *only* supports `POST /` requests, this seems like the least-invasive way to add support for health checks from Runtime Infra -> Sidecar -> Function.  This should ensure that the Function container is a) running, b) listening on its $PORT, c) has a functioning RIFF invoker, d) has a functioning Node process capable of receiving function invocations.

PR for sf-fx-proxy to follow.
