### PR TITLE
Fixed userfn not erroring out if sdk is too old

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "2.0.0"
+version = "2.0.1"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.9.7",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "1.9.7",
+  "version": "2.0.1",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",

--- a/middleware/userFnLoader.ts
+++ b/middleware/userFnLoader.ts
@@ -42,7 +42,7 @@ const enrichFn = function(userFn: Function, userModName: string): EnrichedFuncti
     errmsg = "@salesforce/salesforce-sdk is outdated.";
   }
   if (errmsg && userFn.length === 3) {
-      throw `Cannot build enriched salesforce function. ${errmsg}`;
+    throw `Cannot build enriched salesforce function. ${errmsg}`;
   }
   if (errmsg) {
     console.warn(`Cannot provide enriched salesforce function arguments. ${errmsg}`);
@@ -59,14 +59,16 @@ const enrichFn = function(userFn: Function, userModName: string): EnrichedFuncti
  * @return function - The function to be called
  */
 export default function(packageName: string): EnrichedFunction | Function {
-  if (!packageName) {
-    throw `Could not load salesforce function: package name not defined.`;
-  }
   try {
+    if (!packageName) {
+      throw 'package name not defined.';
+    }
+
     const userMod = require(packageName);
     const userFn = getUserFn(userMod);
     return enrichFn(userFn, packageName);
   } catch (err) {
-    throw `Could not load salesforce function: ${err}`;
+    console.error(`Could not load salesforce function: ${err}`);
+    process.exit(1);
   }
 }


### PR DESCRIPTION
The throw was not causing a failure anymore.