### PR TITLE
Dynamic workspace/build directory

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -7,9 +7,10 @@ LAYERS_DIR="$1"
 echo "LAYERS_DIR: " $LAYERS_DIR
 MW_LAYER="$LAYERS_DIR/middleware"
 echo "MW_LAYER: " $MW_LAYER
+BUILD_DIR=$(pwd)
 
 # Get the package name of the user function, to allow it to be required by name
-SF_FUNCTION_PACKAGE_NAME=$(jq -r '.name // empty' < /workspace/package.json)
+SF_FUNCTION_PACKAGE_NAME=$(jq -r '.name // empty' < "$BUILD_DIR/package.json")
 if [[ -z "${SF_FUNCTION_PACKAGE_NAME}" ]]; then
   echo "Salesforce function package name not defined. Make sure there is a 'name' in package.json."
   exit 1
@@ -58,7 +59,7 @@ if [[ -d "$MW_LAYER/node_modules/$SF_FUNCTION_PACKAGE_NAME" ]]; then
 fi
 echo "Installing $SF_FUNCTION_PACKAGE_NAME"
 echo -n "$SF_FUNCTION_PACKAGE_NAME" > "$MW_LAYER/env/SF_FUNCTION_PACKAGE_NAME.override"
-ln -s /workspace "$MW_LAYER/node_modules/$SF_FUNCTION_PACKAGE_NAME"
+ln -s "$BUILD_DIR" "$MW_LAYER/node_modules/$SF_FUNCTION_PACKAGE_NAME"
 
 mkdir -p "$MW_LAYER/env.launch"
 if [[ ! -z "${DEBUG_PORT}" ]]; then

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "2.0.1"
+version = "2.0.2"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",


### PR DESCRIPTION
This buildpack assumed that builds would always occur in `/workspace`. While this is true in function builds today, as we move toward multiple function architectures, this won't be the case. We might be building in something like `/workspace/function/sms-handler`. This uses `$(pwd)` to figure out the build directory, which matches the [buildpacks spec](https://github.com/buildpacks/spec/blob/main/buildpack.md#build).