### PR TITLE
Use absolute artifact location

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -9,7 +9,7 @@ cat << EOF > "$2"
 name = "riff-node"
 
 [requires.metadata]
-artifact = "../layers/salesforce_nodejs-fn/middleware/dist"
+artifact = "/layers/salesforce_nodejs-fn/middleware/dist"
 EOF
   exit 0
 fi

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "2.0.2"
+version = "2.0.3"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",


### PR DESCRIPTION
The `..` here would cause issues if the build executed in a directory like `/workspace/myfunction` instead of `/workspace`. It was causing Riff to look for the artifact in `/workspace/layers/salesforce_nodejs-fn/middleware/dist`, which doesn't exist. I've tested this change locally with a custom builder and a newly scaffolded salesforce function and it still ran.