### PR TITLE
Artifact needs to be relative

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -9,7 +9,7 @@ cat << EOF > "$2"
 name = "riff-node"
 
 [requires.metadata]
-artifact = "/layers/salesforce_nodejs-fn/middleware/dist"
+artifact = "../../../layers/salesforce_nodejs-fn/middleware/dist"
 EOF
   exit 0
 fi

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.2"
 [buildpack]
 id = "salesforce/nodejs-fn"
 name = "Salesforce NodeJS Function Structured Middleware Buildpack"
-version = "2.0.3"
+version = "2.0.4"
 
 [[stacks]]
 id = "heroku-18"

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-fx-middleware",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Middleware for salesforce functions",
   "license": "UNLICENSED",
   "main": "dist/index.js",


### PR DESCRIPTION
The change made in #66 didn't work with the Riff invoker as expected. Riff wants to join the `artifact` string to the `pwd` to find the artifact. So in the previous PR, it would attempt to find `/workspace/layers/salesforce_nodejs-fn/middleware/dist`, where we want it to look in `/layers/salesforce_nodejs-fn/middleware/dist` . To solve the issue of building in subdirectories of `/workspace` (the problem we wanted to solve in #66), I'm adding a few more parent directory transitions to make sure we get all the way back to root. This should allow builds of up to two directories deep to compile and run.